### PR TITLE
refactor(ui): premium redesign of public blog surface

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,5 @@
-import { Suspense } from "react";
 import type { Metadata } from "next";
 import { BlogPage } from "@/features/blog";
-import { BlogListingSkeleton } from "@/components/shared/LoadingStates";
 import { homeMetadata } from "../../lib/seo/metadata";
 import {
   getBlogsPaginated,
@@ -18,11 +16,9 @@ export default async function BlogListingPage() {
   ]);
 
   return (
-    <Suspense fallback={<BlogListingSkeleton />}>
-      <BlogPage
-        initialBlogs={initialBlogs}
-        initialCategories={initialCategories}
-      />
-    </Suspense>
+    <BlogPage
+      initialBlogs={initialBlogs}
+      initialCategories={initialCategories}
+    />
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,37 +53,12 @@
   --color-brand-light: var(--brand-light);
   --color-brand-dark: var(--brand-dark);
 
-  /* Custom animations */
-  --animate-fade-in: fade-in 0.8s ease forwards;
-  --animate-slide-in: slide-in 0.8s ease forwards;
-  --animate-scale-up: scale-up 0.8s ease forwards;
-  --animate-float: float 3s ease-in-out infinite;
-  --animate-modal-in: modal-in 0.3s ease-out forwards;
-  --animate-modal-out: modal-out 0.3s ease-in forwards;
+  /* Subtle pulse for "new" indicators */
+  --animate-pulse-soft: pulse-soft 2s ease-in-out infinite;
 
-  @keyframes fade-in {
-    0% { opacity: 0; }
-    100% { opacity: 1; }
-  }
-  @keyframes slide-in {
-    0% { opacity: 0; transform: translateY(20px); }
-    100% { opacity: 1; transform: translateY(0); }
-  }
-  @keyframes scale-up {
-    0% { opacity: 0; transform: scale(0.9); }
-    100% { opacity: 1; transform: scale(1); }
-  }
-  @keyframes float {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-10px); }
-  }
-  @keyframes modal-in {
-    0% { opacity: 0; transform: scale(0.95); }
-    100% { opacity: 1; transform: scale(1); }
-  }
-  @keyframes modal-out {
-    0% { opacity: 1; transform: scale(1); }
-    100% { opacity: 0; transform: scale(0.95); }
+  @keyframes pulse-soft {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
   }
 }
 
@@ -121,9 +96,6 @@
   --chart-5: #1e3a8a;
 
   --radius: 0.625rem;
-
-  /* Grid pattern */
-  --grid: #cbd5e1;
 
   /* Sidebar — light */
   --sidebar: #ffffff;
@@ -169,9 +141,6 @@
   --chart-4: #1d4ed8;
   --chart-5: #1e40af;
 
-  /* Grid pattern */
-  --grid: #1e1e2a;
-
   /* Sidebar — dark */
   --sidebar: #111118;
   --sidebar-foreground: #f1f5f9;
@@ -200,27 +169,40 @@
     scroll-behavior: smooth;
   }
 
-  /* Responsive typography — aligned with main ndevuspace site */
+  /*
+   * Typography roles — modest element defaults so semantic headings never
+   * leak hero sizing into components; hero scale is opted into per usage.
+   * Body copy keeps full foreground contrast; muted is reserved for metadata.
+   */
   h1 {
-    @apply text-4xl md:text-5xl lg:text-6xl font-bold leading-tight tracking-tight;
+    @apply text-3xl md:text-4xl font-bold leading-tight tracking-tight;
   }
   h2 {
-    @apply text-3xl md:text-4xl lg:text-5xl font-bold leading-tight;
+    @apply text-2xl md:text-3xl font-bold leading-tight tracking-tight;
   }
   h3 {
-    @apply text-2xl md:text-3xl font-semibold;
+    @apply text-xl font-semibold tracking-tight;
   }
   h4 {
-    @apply text-xl md:text-2xl font-semibold;
+    @apply text-lg font-semibold;
+  }
+  h1, h2, h3, h4 {
+    text-wrap: balance;
   }
   p {
-    @apply text-muted-foreground leading-relaxed;
+    @apply leading-relaxed;
   }
 
-  /* Selection styling */
+  /* Selection styling — theme-aware, readable in both modes */
   ::selection {
-    background: rgba(59, 130, 246, 0.3);
-    color: #fff;
+    background: color-mix(in oklab, var(--primary) 25%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html,
+    body {
+      scroll-behavior: auto;
+    }
   }
 
   /* Custom scrollbar */
@@ -244,71 +226,25 @@
 
 /* ─── Utility Classes ─── */
 @layer utilities {
-  /* Text gradient */
-  .text-gradient {
-    @apply bg-gradient-to-r from-blue-400 via-purple-400 to-blue-500 bg-clip-text text-transparent;
-  }
-
-  /* Glass morphism */
+  /* Glass morphism — frosted surface over page content; borders stay contextual */
   .glass {
-    @apply bg-gray-100/80 dark:bg-white/5 backdrop-blur-xl border border-gray-200 dark:border-white/10;
+    @apply bg-background/70 backdrop-blur-md;
   }
 
-  /* Glow effects */
-  .glow {
-    box-shadow: 0 0 40px rgba(59, 130, 246, 0.3);
-  }
-  .glow-hover:hover {
-    box-shadow: 0 0 60px rgba(59, 130, 246, 0.4);
+  /* Glass strip over imagery — dark scrim regardless of theme */
+  .glass-scrim {
+    @apply bg-black/45 backdrop-blur-md border border-white/15 text-white/95;
   }
 
-  /* Background patterns */
-  .bg-grid {
-    background-image: linear-gradient(to right, rgba(0,0,0,0.08) 1px, transparent 1px),
-                      linear-gradient(to bottom, rgba(0,0,0,0.08) 1px, transparent 1px);
-    background-size: 60px 60px;
+  /*
+   * Type roles (shared across public pages):
+   * eyebrow — mono section label; meta — mono metadata line.
+   */
+  .text-eyebrow {
+    @apply font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-primary;
   }
-
-  .dark .bg-grid {
-    background-image: linear-gradient(to right, rgba(255,255,255,0.08) 1px, transparent 1px),
-                      linear-gradient(to bottom, rgba(255,255,255,0.08) 1px, transparent 1px);
-  }
-
-  /* Grid pattern with better visibility */
-  .bg-grid-subtle {
-    background-image: linear-gradient(to right, var(--grid) 1px, transparent 1px),
-                      linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
-    background-size: 4rem 4rem;
-    opacity: 0.25;
-  }
-
-  .bg-dots {
-    background-image: radial-gradient(circle, rgba(0,0,0,0.05) 1px, transparent 1px);
-    background-size: 30px 30px;
-  }
-
-  .dark .bg-dots {
-    background-image: radial-gradient(circle, rgba(255,255,255,0.08) 1px, transparent 1px);
-  }
-
-  /* Scrollbar hide */
-  .scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-
-  /* Section fade-in animation */
-  .section-fade {
-    opacity: 0;
-    transform: translateY(30px);
-    transition: opacity 0.8s ease-out, transform 0.8s ease-out;
-  }
-  .section-fade.visible {
-    opacity: 1;
-    transform: translateY(0);
+  .text-meta {
+    @apply font-mono text-xs tracking-wide text-muted-foreground;
   }
 }
 
@@ -316,8 +252,8 @@
 @layer components {
   .prose-blog {
     @apply prose prose-lg max-w-none;
-    @apply prose-headings:text-foreground prose-headings:font-bold;
-    @apply prose-p:text-muted-foreground prose-p:leading-relaxed;
+    @apply prose-headings:text-foreground prose-headings:font-bold prose-headings:tracking-tight;
+    @apply prose-p:text-foreground/90 prose-p:leading-relaxed;
     @apply prose-a:text-brand prose-a:underline prose-a:font-medium;
     @apply prose-strong:text-foreground prose-strong:font-semibold;
     @apply prose-blockquote:border-l-4 prose-blockquote:border-brand prose-blockquote:italic prose-blockquote:text-muted-foreground;
@@ -325,7 +261,7 @@
     @apply prose-pre:bg-muted prose-pre:text-foreground prose-pre:rounded-lg prose-pre:overflow-auto prose-pre:text-sm;
     @apply prose-img:rounded-lg prose-img:my-8;
     @apply prose-hr:border-border;
-    @apply prose-li:text-muted-foreground;
+    @apply prose-li:text-foreground/90;
     @apply prose-ul:list-disc prose-ol:list-decimal;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -237,6 +237,15 @@
   }
 
   /*
+   * Press feedback for tappable chips/buttons. Sets only the active scale —
+   * pair with a transition that covers transform (transition-all or
+   * transition-transform) on the consumer.
+   */
+  .pressable {
+    @apply motion-safe:active:scale-[0.97];
+  }
+
+  /*
    * Type roles (shared across public pages):
    * eyebrow — mono section label; meta — mono metadata line.
    */

--- a/src/components/shared/EmptyState.tsx
+++ b/src/components/shared/EmptyState.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/ui/button";
+
+export interface EmptyStateProps {
+  /** Illustrative element shown above the title (icon, emoji, …). */
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  className?: string;
+}
+
+/**
+ * Centered empty/error state: icon, title, supporting copy, and an
+ * optional recovery action.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={`py-12 text-center ${className ?? ""}`}>
+      {icon && (
+        <div className="mb-4 flex justify-center text-muted-foreground">
+          {icon}
+        </div>
+      )}
+      <h3 className="mb-2 text-xl font-bold">{title}</h3>
+      {description && <p className="text-muted-foreground">{description}</p>}
+      {actionLabel && onAction && (
+        <Button variant="link" className="mt-4 text-primary" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/LoadingStates.tsx
+++ b/src/components/shared/LoadingStates.tsx
@@ -2,24 +2,25 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 /**
- * Blog card skeleton for loading states
+ * Blog card skeleton — mirrors BlogCard's cover/title/excerpt/footer anatomy
  */
 export function BlogCardSkeleton() {
   return (
-    <Card className="overflow-hidden">
-      <Skeleton className="h-48 w-full rounded-none" />
-      <CardHeader className="space-y-2">
-        <Skeleton className="h-4 w-20" />
+    <Card className="h-full gap-0 overflow-hidden py-0">
+      <Skeleton className="aspect-video w-full rounded-none" />
+      <CardContent className="flex flex-col gap-3 p-5">
         <Skeleton className="h-6 w-full" />
         <Skeleton className="h-6 w-3/4" />
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-5/6" />
-        <div className="flex items-center gap-2 pt-2">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+        <div className="flex items-center justify-between border-t border-border pt-4">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-7 w-7 rounded-full" />
+            <Skeleton className="h-4 w-24" />
+          </div>
           <Skeleton className="h-8 w-8 rounded-full" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-20 ml-auto" />
         </div>
       </CardContent>
     </Card>

--- a/src/components/shared/ReadingProgress.tsx
+++ b/src/components/shared/ReadingProgress.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { motion, useScroll, useSpring, useReducedMotion } from "framer-motion";
+
+/**
+ * Fixed hairline progress bar under the sticky header that tracks page
+ * scroll. Renders statically (no spring) when the user prefers reduced motion.
+ */
+export function ReadingProgress() {
+  const { scrollYProgress } = useScroll();
+  const prefersReducedMotion = useReducedMotion();
+  const smoothProgress = useSpring(scrollYProgress, {
+    stiffness: 140,
+    damping: 30,
+    restDelta: 0.001,
+  });
+
+  return (
+    <motion.div
+      aria-hidden
+      className="fixed inset-x-0 top-16 z-50 h-0.5 origin-left bg-gradient-to-r from-brand-dark via-brand to-brand-light"
+      style={{ scaleX: prefersReducedMotion ? scrollYProgress : smoothProgress }}
+    />
+  );
+}

--- a/src/components/shared/Reveal.tsx
+++ b/src/components/shared/Reveal.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { DURATION, EASE_OUT } from "@/lib/motion";
+
+interface RevealProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Seconds to hold before the reveal starts once in view. */
+  delay?: number;
+}
+
+/**
+ * Reveals its children with a fade-rise the first time they scroll into
+ * view. Renders statically when the user prefers reduced motion.
+ */
+export function Reveal({ children, className, delay = 0 }: RevealProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 16 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-64px" }}
+      transition={{ duration: DURATION.slow, ease: EASE_OUT, delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/shared/SectionHeading.tsx
+++ b/src/components/shared/SectionHeading.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+type HeadingLevel = "h2" | "h3";
+
+export interface SectionHeadingProps {
+  /** Mono uppercase label rendered above the title. */
+  eyebrow?: string;
+  title: string;
+  /** Mono metadata line rendered below the title, e.g. "Showing 12 of 24 posts". */
+  meta?: string;
+  as?: HeadingLevel;
+  className?: string;
+  titleClassName?: string;
+}
+
+/**
+ * Section header in the site's editorial voice: mono eyebrow, balanced
+ * title, optional mono meta line. Single source for what used to be the
+ * colored-bar heading pattern.
+ */
+export function SectionHeading({
+  eyebrow,
+  title,
+  meta,
+  as: Heading = "h2",
+  className,
+  titleClassName,
+}: SectionHeadingProps) {
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      {eyebrow && (
+        <span className="text-eyebrow flex items-center gap-2.5">
+          <span aria-hidden className="h-px w-5 bg-primary" />
+          {eyebrow}
+        </span>
+      )}
+      <Heading className={cn("text-foreground", titleClassName)}>
+        {title}
+      </Heading>
+      {meta && <p className="text-meta tabular-nums">{meta}</p>}
+    </div>
+  );
+}

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -4,6 +4,7 @@ import type { BlogCategory, BlogPost } from "@/types/blog";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { BlogSidebar } from "./components/BlogSidebar";
 import { ShareArticle } from "./components/ShareArticle";
 import { TableOfContents } from "./components/TableOfContents";
@@ -28,7 +29,9 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ReadingProgress } from "@/components/shared/ReadingProgress";
+import { Reveal } from "@/components/shared/Reveal";
 import { SectionHeading } from "@/components/shared/SectionHeading";
+import { fadeRise, fadeScale, staggerContainer, SPRING_SNAPPY } from "@/lib/motion";
 import { Calendar, Clock, Heart } from "lucide-react";
 import { toast } from "sonner";
 
@@ -39,6 +42,7 @@ interface BlogDetailPageProps {
 
 export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
   const router = useRouter();
+  const prefersReducedMotion = useReducedMotion();
 
   // ─── Store ───
   const {
@@ -109,36 +113,46 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
     <>
       <ReadingProgress />
 
-      {/* Article Header */}
+      {/* Article Header — staged reveal: breadcrumb → title block → meta → image → lede */}
       <section className="relative bg-card pt-24 pb-16">
-        <div className="max-w-4xl mx-auto px-4">
+        <motion.div
+          className="max-w-4xl mx-auto px-4"
+          variants={staggerContainer(0.09)}
+          initial={prefersReducedMotion ? false : "hidden"}
+          animate="visible"
+        >
           {/* Breadcrumb */}
-          <Breadcrumb className="mb-8">
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbLink href="/blog">Blog</BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage className="truncate max-w-[200px]">
-                  {post.title}
-                </BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
+          <motion.div variants={fadeRise}>
+            <Breadcrumb className="mb-8">
+              <BreadcrumbList>
+                <BreadcrumbItem>
+                  <BreadcrumbLink href="/blog">Blog</BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage className="truncate max-w-[200px]">
+                    {post.title}
+                  </BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+          </motion.div>
 
-          {/* Category eyebrow */}
-          <p className="text-eyebrow mb-4">
-            {post.category?.name || "Uncategorized"}
-          </p>
-
-          {/* Title */}
-          <h1 className="text-3xl md:text-5xl font-bold tracking-tight mb-6 leading-tight">
-            {post.title}
-          </h1>
+          {/* Category eyebrow + title */}
+          <motion.div variants={fadeRise}>
+            <p className="text-eyebrow mb-4">
+              {post.category?.name || "Uncategorized"}
+            </p>
+            <h1 className="text-3xl md:text-5xl font-bold tracking-tight mb-6 leading-tight">
+              {post.title}
+            </h1>
+          </motion.div>
 
           {/* Meta Information */}
-          <div className="flex flex-wrap items-center gap-6 mb-8">
+          <motion.div
+            variants={fadeRise}
+            className="flex flex-wrap items-center gap-6 mb-8"
+          >
             <div className="flex items-center">
               <Avatar className="h-12 w-12 border-2 border-primary mr-3">
                 <AvatarImage src={getAuthorImage(post)} alt={authorName} />
@@ -154,11 +168,14 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
               <Clock className="h-4 w-4" />
               {post.readTime || "5 min read"}
             </span>
-          </div>
+          </motion.div>
 
           {/* Featured Image */}
           {post.imageUrl?.trim() && (
-            <div className="relative w-full h-64 md:h-96 rounded-xl overflow-hidden mb-8">
+            <motion.div
+              variants={fadeScale}
+              className="relative w-full h-64 md:h-96 rounded-xl overflow-hidden mb-8"
+            >
               <Image
                 src={heroImageSrc}
                 alt={post.title}
@@ -166,14 +183,17 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
                 className="object-cover"
                 priority
               />
-            </div>
+            </motion.div>
           )}
 
           {/* Description */}
-          <p className="text-xl text-foreground/80 leading-relaxed">
+          <motion.p
+            variants={fadeRise}
+            className="text-xl text-foreground/80 leading-relaxed"
+          >
             {post.description}
-          </p>
-        </div>
+          </motion.p>
+        </motion.div>
       </section>
 
       {/* Article Content */}
@@ -229,55 +249,69 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
                   variant={liked ? "default" : "outline"}
                   size="sm"
                   onClick={handleLike}
-                  className="gap-1.5 rounded-full"
+                  className="gap-1.5 rounded-full transition-transform motion-safe:active:scale-95"
                 >
-                  <Heart className={`h-4 w-4 ${liked ? "fill-current" : ""}`} />
+                  <motion.span
+                    animate={
+                      liked && !prefersReducedMotion
+                        ? { scale: [1, 1.4, 1] }
+                        : { scale: 1 }
+                    }
+                    transition={SPRING_SNAPPY}
+                    className="inline-flex"
+                  >
+                    <Heart
+                      className={`h-4 w-4 ${liked ? "fill-current" : ""}`}
+                    />
+                  </motion.span>
                   <span className="tabular-nums">{likeCount}</span>
                 </Button>
               </div>
             </article>
 
-            {/* Related Posts */}
+            {/* Related Posts — revealed as the reader reaches them */}
             {relatedPosts.length > 0 && (
-              <section className="mt-14">
-                <SectionHeading
-                  eyebrow="Keep reading"
-                  title="Related Articles"
-                  className="mb-6"
-                />
-                <div className="grid md:grid-cols-3 gap-6">
-                  {relatedPosts.map((relatedPost) => (
-                    <Link
-                      key={relatedPost.id}
-                      href={`/blog/${relatedPost.slug}`}
-                      className="group h-full"
-                    >
-                      <Card className="h-full gap-0 overflow-hidden py-0 transition-all duration-300 group-hover:ring-primary/40 group-hover:shadow-[0_16px_40px_-18px] group-hover:shadow-primary/35 motion-safe:group-hover:-translate-y-0.5">
-                        <div className="relative aspect-video overflow-hidden">
-                          <Image
-                            src={getSafeImageSrc(
-                              relatedPost.imageUrl,
-                              "/images/blog/placeholder.jpg"
-                            )}
-                            alt={relatedPost.title}
-                            fill
-                            sizes="(max-width: 768px) 100vw, 25vw"
-                            className="object-cover transition-transform duration-300 motion-safe:group-hover:scale-[1.03]"
-                          />
-                        </div>
-                        <CardContent className="flex flex-col gap-2 p-4">
-                          <h4 className="line-clamp-2 text-base font-semibold leading-snug transition-colors duration-200 group-hover:text-primary">
-                            {relatedPost.title}
-                          </h4>
-                          <p className="text-meta">
-                            {relatedPost.readTime || "5 min read"}
-                          </p>
-                        </CardContent>
-                      </Card>
-                    </Link>
-                  ))}
-                </div>
-              </section>
+              <Reveal className="mt-14">
+                <section>
+                  <SectionHeading
+                    eyebrow="Keep reading"
+                    title="Related Articles"
+                    className="mb-6"
+                  />
+                  <div className="grid md:grid-cols-3 gap-6">
+                    {relatedPosts.map((relatedPost) => (
+                      <Link
+                        key={relatedPost.id}
+                        href={`/blog/${relatedPost.slug}`}
+                        className="group h-full"
+                      >
+                        <Card className="h-full gap-0 overflow-hidden py-0 transition-all duration-300 group-hover:ring-primary/40 group-hover:shadow-[0_16px_40px_-18px] group-hover:shadow-primary/35 motion-safe:group-hover:-translate-y-0.5">
+                          <div className="relative aspect-video overflow-hidden">
+                            <Image
+                              src={getSafeImageSrc(
+                                relatedPost.imageUrl,
+                                "/images/blog/placeholder.jpg"
+                              )}
+                              alt={relatedPost.title}
+                              fill
+                              sizes="(max-width: 768px) 100vw, 25vw"
+                              className="object-cover transition-transform duration-300 motion-safe:group-hover:scale-[1.03]"
+                            />
+                          </div>
+                          <CardContent className="flex flex-col gap-2 p-4">
+                            <h4 className="line-clamp-2 text-base font-semibold leading-snug transition-colors duration-200 group-hover:text-primary">
+                              {relatedPost.title}
+                            </h4>
+                            <p className="text-meta">
+                              {relatedPost.readTime || "5 min read"}
+                            </p>
+                          </CardContent>
+                        </Card>
+                      </Link>
+                    ))}
+                  </div>
+                </section>
+              </Reveal>
             )}
           </div>
 

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -27,12 +27,9 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  Bookmark,
-  Calendar,
-  Clock,
-  Heart,
-} from "lucide-react";
+import { ReadingProgress } from "@/components/shared/ReadingProgress";
+import { SectionHeading } from "@/components/shared/SectionHeading";
+import { Calendar, Clock, Heart } from "lucide-react";
 import { toast } from "sonner";
 
 interface BlogDetailPageProps {
@@ -110,16 +107,14 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
 
   return (
     <>
+      <ReadingProgress />
+
       {/* Article Header */}
       <section className="relative bg-card pt-24 pb-16">
         <div className="max-w-4xl mx-auto px-4">
           {/* Breadcrumb */}
           <Breadcrumb className="mb-8">
             <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbLink href="/blog">Home</BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
               <BreadcrumbItem>
                 <BreadcrumbLink href="/blog">Blog</BreadcrumbLink>
               </BreadcrumbItem>
@@ -132,50 +127,33 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
             </BreadcrumbList>
           </Breadcrumb>
 
-          {/* Category Badge */}
-          <div className="mb-6">
-            <Badge variant="secondary">
-              <Bookmark className="h-3 w-3 mr-1" />
-              {post.category?.name || "Uncategorized"}
-            </Badge>
-          </div>
+          {/* Category eyebrow */}
+          <p className="text-eyebrow mb-4">
+            {post.category?.name || "Uncategorized"}
+          </p>
 
           {/* Title */}
-          <h1 className="text-3xl md:text-5xl font-bold mb-6 leading-tight">
+          <h1 className="text-3xl md:text-5xl font-bold tracking-tight mb-6 leading-tight">
             {post.title}
           </h1>
 
           {/* Meta Information */}
-          <div className="flex flex-wrap items-center gap-6 mb-8 text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-6 mb-8">
             <div className="flex items-center">
               <Avatar className="h-12 w-12 border-2 border-primary mr-3">
                 <AvatarImage src={getAuthorImage(post)} alt={authorName} />
                 <AvatarFallback>{authorName.charAt(0)}</AvatarFallback>
               </Avatar>
-              <div>
-                <p className="font-medium text-foreground">{authorName}</p>
-              </div>
+              <p className="font-medium text-foreground">{authorName}</p>
             </div>
-            <div className="flex items-center text-sm gap-1">
+            <span className="text-meta flex items-center gap-1.5">
               <Calendar className="h-4 w-4" />
               {formatDate(post.createdAt)}
-            </div>
-            <div className="flex items-center text-sm gap-1">
+            </span>
+            <span className="text-meta flex items-center gap-1.5">
               <Clock className="h-4 w-4" />
               {post.readTime || "5 min read"}
-            </div>
-            {/* Like Button */}
-            <Button
-              variant={liked ? "default" : "outline"}
-              size="sm"
-              onClick={handleLike}
-              className="gap-1"
-            >
-              <Heart
-                className={`h-4 w-4 ${liked ? "fill-current" : ""}`}
-              />
-              {likeCount}
-            </Button>
+            </span>
           </div>
 
           {/* Featured Image */}
@@ -192,11 +170,9 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
           )}
 
           {/* Description */}
-          <div className="prose prose-lg dark:prose-invert max-w-none mb-8">
-            <p className="text-xl text-muted-foreground leading-relaxed">
-              {post.description}
-            </p>
-          </div>
+          <p className="text-xl text-foreground/80 leading-relaxed">
+            {post.description}
+          </p>
         </div>
       </section>
 
@@ -213,72 +189,71 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
             <TableOfContents />
           </div>
 
-          {/* Article Content */}
+          {/* Article Content — long-form reads on the open page, no card chrome */}
           <div className="lg:w-3/5">
-            <Card>
-              <CardContent className="p-8">
-                {/* Article Body */}
-                <div
-                  className="prose-blog prose prose-lg dark:prose-invert max-w-none"
-                  data-article-content
-                >
-                  {post.content ? (
-                    <div dangerouslySetInnerHTML={{ __html: post.content }} />
-                  ) : (
-                    <div className="space-y-6" />
-                  )}
-                </div>
-
-                {/* Tags */}
-                <div className="mt-8 pt-6 border-t border-border">
-                  <h3 className="text-lg font-semibold mb-4">Tags</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {post.tags.map((tag) => (
-                      <button key={tag} onClick={() => handleTagClick(tag)}>
-                        <Badge
-                          variant="secondary"
-                          className="cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
-                        >
-                          #{tag}
-                        </Badge>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Share Article */}
-                {currentUrl && (
-                  <ShareArticle
-                    title={post.title}
-                    url={currentUrl}
-                    className="mt-6 pt-6 border-t border-border"
-                    inline={true}
-                  />
+            <article>
+              <div
+                className="prose-blog prose prose-lg dark:prose-invert max-w-none"
+                data-article-content
+              >
+                {post.content ? (
+                  <div dangerouslySetInnerHTML={{ __html: post.content }} />
+                ) : (
+                  <div className="space-y-6" />
                 )}
-              </CardContent>
-            </Card>
+              </div>
 
-            {/* Comments Section */}
-            {/* <section className="mt-12 space-y-8">
-              <CommentList comments={comments} />
-              <CommentForm
-                blogId={post.id}
-                onCommentAdded={addComment}
-              />
-            </section> */}
+              {/* Tags */}
+              <div className="mt-10 flex flex-col gap-3 border-t border-border pt-6">
+                <h3 className="text-eyebrow">Tags</h3>
+                <div className="flex flex-wrap gap-2">
+                  {post.tags.map((tag) => (
+                    <button key={tag} onClick={() => handleTagClick(tag)}>
+                      <Badge
+                        variant="secondary"
+                        className="cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
+                      >
+                        #{tag}
+                      </Badge>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Actions — share & appreciation in one cluster */}
+              <div className="mt-6 flex flex-wrap items-end justify-between gap-6 border-t border-border pt-6">
+                {currentUrl && (
+                  <ShareArticle title={post.title} url={currentUrl} />
+                )}
+                <Button
+                  variant={liked ? "default" : "outline"}
+                  size="sm"
+                  onClick={handleLike}
+                  className="gap-1.5 rounded-full"
+                >
+                  <Heart className={`h-4 w-4 ${liked ? "fill-current" : ""}`} />
+                  <span className="tabular-nums">{likeCount}</span>
+                </Button>
+              </div>
+            </article>
 
             {/* Related Posts */}
             {relatedPosts.length > 0 && (
-              <section className="mt-12">
-                <h3 className="text-2xl font-bold mb-6">Related Articles</h3>
+              <section className="mt-14">
+                <SectionHeading
+                  eyebrow="Keep reading"
+                  title="Related Articles"
+                  className="mb-6"
+                />
                 <div className="grid md:grid-cols-3 gap-6">
                   {relatedPosts.map((relatedPost) => (
                     <Link
                       key={relatedPost.id}
                       href={`/blog/${relatedPost.slug}`}
+                      className="group h-full"
                     >
-                      <Card className="overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 h-full">
-                        <div className="relative w-full h-40">
+                      <Card className="h-full gap-0 overflow-hidden py-0 transition-all duration-300 group-hover:ring-primary/40 group-hover:shadow-[0_16px_40px_-18px] group-hover:shadow-primary/35 motion-safe:group-hover:-translate-y-0.5">
+                        <div className="relative aspect-video overflow-hidden">
                           <Image
                             src={getSafeImageSrc(
                               relatedPost.imageUrl,
@@ -286,14 +261,15 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
                             )}
                             alt={relatedPost.title}
                             fill
-                            className="object-cover"
+                            sizes="(max-width: 768px) 100vw, 25vw"
+                            className="object-cover transition-transform duration-300 motion-safe:group-hover:scale-[1.03]"
                           />
                         </div>
-                        <CardContent className="p-4">
-                          <h4 className="font-semibold mb-2 overflow-hidden max-h-[3rem]">
+                        <CardContent className="flex flex-col gap-2 p-4">
+                          <h4 className="line-clamp-2 text-base font-semibold leading-snug transition-colors duration-200 group-hover:text-primary">
                             {relatedPost.title}
                           </h4>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-meta">
                             {relatedPost.readTime || "5 min read"}
                           </p>
                         </CardContent>
@@ -306,17 +282,18 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
           </div>
 
           {/* Right Sidebar */}
-          <aside className="lg:w-1/5 space-y-8">
-
-            <BlogSidebar
-              categories={categories}
-              activeCategory={post.category?.id ?? "all"}
-              onCategoryChange={handleCategoryChange}
-              isSearchActive={false}
-              tags={allTags}
-              onTagClick={handleTagClick}
-              activeTag={null}
-            />
+          <aside className="lg:w-1/5">
+            <div className="lg:sticky lg:top-24">
+              <BlogSidebar
+                categories={categories}
+                activeCategory={post.category?.id ?? "all"}
+                onCategoryChange={handleCategoryChange}
+                isSearchActive={false}
+                tags={allTags}
+                onTagClick={handleTagClick}
+                activeTag={null}
+              />
+            </div>
           </aside>
         </div>
       </main>

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -2,9 +2,9 @@
 
 import type { BlogCategory, BlogPost } from "@/types/blog";
 import Image from "next/image";
-import Link from "next/link";
 import { useEffect } from "react";
 import { motion, useReducedMotion } from "framer-motion";
+import { BlogCard } from "./components/BlogCard";
 import { BlogSidebar } from "./components/BlogSidebar";
 import { ShareArticle } from "./components/ShareArticle";
 import { TableOfContents } from "./components/TableOfContents";
@@ -12,8 +12,9 @@ import { useBlogDetailStore } from "./detailStore";
 import {
   getAuthorName,
   getAuthorImage,
+  getPostImageSrc,
+  getReadTime,
   formatDate,
-  getSafeImageSrc,
 } from "@/lib/blogUtils";
 import { useRouter } from "next/navigation";
 import {
@@ -26,7 +27,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ReadingProgress } from "@/components/shared/ReadingProgress";
 import { Reveal } from "@/components/shared/Reveal";
@@ -107,7 +107,7 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
   }
 
   const authorName = getAuthorName(post.author);
-  const heroImageSrc = getSafeImageSrc(post.imageUrl, "/images/blog/placeholder.jpg");
+  const heroImageSrc = getPostImageSrc(post);
 
   return (
     <>
@@ -166,7 +166,7 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
             </span>
             <span className="text-meta flex items-center gap-1.5">
               <Clock className="h-4 w-4" />
-              {post.readTime || "5 min read"}
+              {getReadTime(post)}
             </span>
           </motion.div>
 
@@ -228,7 +228,11 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
                 <h3 className="text-eyebrow">Tags</h3>
                 <div className="flex flex-wrap gap-2">
                   {post.tags.map((tag) => (
-                    <button key={tag} onClick={() => handleTagClick(tag)}>
+                    <button
+                      key={tag}
+                      onClick={() => handleTagClick(tag)}
+                      className="pressable transition-transform duration-150"
+                    >
                       <Badge
                         variant="secondary"
                         className="cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
@@ -249,7 +253,7 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
                   variant={liked ? "default" : "outline"}
                   size="sm"
                   onClick={handleLike}
-                  className="gap-1.5 rounded-full transition-transform motion-safe:active:scale-95"
+                  className="pressable gap-1.5 rounded-full transition-transform"
                 >
                   <motion.span
                     animate={
@@ -280,34 +284,11 @@ export function BlogDetailPage({ post, categories }: BlogDetailPageProps) {
                   />
                   <div className="grid md:grid-cols-3 gap-6">
                     {relatedPosts.map((relatedPost) => (
-                      <Link
+                      <BlogCard
                         key={relatedPost.id}
-                        href={`/blog/${relatedPost.slug}`}
-                        className="group h-full"
-                      >
-                        <Card className="h-full gap-0 overflow-hidden py-0 transition-all duration-300 group-hover:ring-primary/40 group-hover:shadow-[0_16px_40px_-18px] group-hover:shadow-primary/35 motion-safe:group-hover:-translate-y-0.5">
-                          <div className="relative aspect-video overflow-hidden">
-                            <Image
-                              src={getSafeImageSrc(
-                                relatedPost.imageUrl,
-                                "/images/blog/placeholder.jpg"
-                              )}
-                              alt={relatedPost.title}
-                              fill
-                              sizes="(max-width: 768px) 100vw, 25vw"
-                              className="object-cover transition-transform duration-300 motion-safe:group-hover:scale-[1.03]"
-                            />
-                          </div>
-                          <CardContent className="flex flex-col gap-2 p-4">
-                            <h4 className="line-clamp-2 text-base font-semibold leading-snug transition-colors duration-200 group-hover:text-primary">
-                              {relatedPost.title}
-                            </h4>
-                            <p className="text-meta">
-                              {relatedPost.readTime || "5 min read"}
-                            </p>
-                          </CardContent>
-                        </Card>
-                      </Link>
+                        post={relatedPost}
+                        variant="compact"
+                      />
                     ))}
                   </div>
                 </section>

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useEffect, useRef } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { BlogCard } from "./components/BlogCard";
+import { BlogGrid, BlogGridSkeleton } from "./components/BlogGrid";
 import { BlogSidebar } from "./components/BlogSidebar";
 import { CategoryTabs } from "./components/CategoryTabs";
 import { BlogSearch } from "./components/BlogSearch";
@@ -18,8 +18,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { BlogCardSkeleton } from "@/components/shared/LoadingStates";
-import { Loader2, Plus, Search, X } from "lucide-react";
+import { SectionHeading } from "@/components/shared/SectionHeading";
+import { Loader2, Plus, Search, SearchX, X } from "lucide-react";
 import { useBlogUrlParams } from "@/hooks";
 import type { BlogCategory, PaginatedBlogsResponse } from "@/types/blog";
 
@@ -43,6 +43,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
     searchQuery,
     sortBy,
     hasMorePosts,
+    totalCount,
     blogsLoading,
     categoriesLoading,
     categoryLoading,
@@ -131,6 +132,14 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
   const isContentLoading =
     blogsLoading || categoryLoading || tagLoading || searchLoading;
 
+  const hasActiveFilters =
+    Boolean(searchQuery.trim()) || Boolean(activeTag) || activeCategory !== "all";
+
+  const showingMeta =
+    !isContentLoading && !error && filteredPosts.length > 0
+      ? `Showing ${filteredPosts.length} of ${totalCount} ${totalCount === 1 ? "post" : "posts"}`
+      : undefined;
+
   return (
     <main className="bg-background pt-28 md:pt-32">
       {/* Search — above filters & listing; wired via useBlogUrlParams + store */}
@@ -139,9 +148,9 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
       </div>
 
       {/* Sticky filters: category tabs only below lg (desktop uses sidebar categories) */}
-      <div className="sticky top-16 z-10 backdrop-blur-sm">
+      <div className="sticky top-16 z-10">
         {searchQuery.trim() && (
-          <div className="bg-primary/5 border-b border-primary/20 py-3">
+          <div className="glass bg-primary/5 border-b border-primary/20 py-3">
             <div className="max-w-6xl mx-auto px-4">
               <div className="flex items-center justify-center gap-2 text-sm text-primary">
                 <Search className="h-4 w-4" />
@@ -160,7 +169,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         )}
 
         {categoriesLoading ? (
-          <div className="lg:hidden bg-muted/50 py-4 border-y border-border/50">
+          <div className="lg:hidden glass py-4 border-y border-border/60">
             <div className="max-w-6xl mx-auto px-4">
               <div className="flex justify-center py-2 gap-2">
                 {Array.from({ length: 4 }).map((_, i) => (
@@ -183,9 +192,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         {activeTag && (
           <div className="max-w-6xl mx-auto px-4 mt-4 pb-2">
             <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">
-                Filtering by tag:
-              </span>
+              <span className="text-meta">Filtering by tag:</span>
               <Badge variant="default" className="gap-1">
                 #{activeTag}
                 <button
@@ -205,128 +212,127 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         <div className="flex flex-col lg:flex-row gap-8">
           {/* Main Content */}
           <div className="lg:w-3/4">
-            {blogsLoading ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <BlogCardSkeleton key={i} />
-                ))}
+            {/* Listing header: heading + count, sort control */}
+            <div className="mb-8 flex flex-col md:flex-row justify-between md:items-end gap-4">
+              <div className="flex items-center gap-4">
+                <SectionHeading
+                  eyebrow="Journal"
+                  title={searchQuery ? "Search Results" : "Latest Articles"}
+                  meta={showingMeta}
+                />
+                {searchQuery && (
+                  <button
+                    onClick={onClearSearch}
+                    className="text-sm text-muted-foreground hover:text-primary flex items-center gap-1 transition-colors"
+                  >
+                    <X className="h-4 w-4" />
+                    Clear
+                  </button>
+                )}
+              </div>
+
+              <div className="flex items-center gap-3">
+                <span className="text-meta">Sort by</span>
+                <Select
+                  value={sortBy}
+                  onValueChange={(value) =>
+                    setSortBy(value as "newest" | "oldest" | "popular")
+                  }
+                >
+                  <SelectTrigger className="w-[160px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="newest">Newest First</SelectItem>
+                    <SelectItem value="oldest">Oldest First</SelectItem>
+                    <SelectItem value="popular">Most Popular</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {/* Blog Grid */}
+            {error ? (
+              <div className="text-center py-12">
+                <div className="text-6xl mb-4">&#x26A0;&#xFE0F;</div>
+                <h3 className="text-xl font-bold mb-2">{error}</h3>
+                <p className="text-muted-foreground">
+                  Please try a different category or clear your search.
+                </p>
+                <Button
+                  variant="link"
+                  className="mt-4 text-primary"
+                  onClick={onClearAllFilters}
+                >
+                  Clear and view all articles
+                </Button>
+              </div>
+            ) : isContentLoading ? (
+              <BlogGridSkeleton />
+            ) : filteredPosts.length === 0 ? (
+              <div className="text-center py-12">
+                <SearchX className="mx-auto mb-4 h-10 w-10 text-muted-foreground" />
+                <h3 className="text-xl font-bold mb-2">No articles found</h3>
+                <p className="text-muted-foreground">
+                  Nothing matches the current filters.
+                </p>
+                {hasActiveFilters && (
+                  <Button
+                    variant="link"
+                    className="mt-4 text-primary"
+                    onClick={onClearAllFilters}
+                  >
+                    Clear and view all articles
+                  </Button>
+                )}
               </div>
             ) : (
               <>
-                {/* Sort Options */}
-                <div className="mb-8 flex flex-col md:flex-row justify-between items-center gap-4">
-                  <div className="flex items-center gap-4">
-                    <h2 className="text-xl font-bold flex items-center">
-                      <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-                      {searchQuery
-                        ? `Search Results (${filteredPosts.length})`
-                        : "Latest Articles"}
-                    </h2>
-                    {searchQuery && (
-                      <button
-                        onClick={onClearSearch}
-                        className="text-sm text-muted-foreground hover:text-primary flex items-center gap-1 transition-colors"
-                      >
-                        <X className="h-4 w-4" />
-                        Clear
-                      </button>
-                    )}
-                  </div>
+                <BlogGrid
+                  posts={filteredPosts}
+                  featureFirst={!hasActiveFilters}
+                />
 
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm text-muted-foreground">
-                      Sort by:
-                    </span>
-                    <Select
-                      value={sortBy}
-                      onValueChange={(value) =>
-                        setSortBy(value as "newest" | "oldest" | "popular")
-                      }
-                    >
-                      <SelectTrigger className="w-[160px]">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="newest">Newest First</SelectItem>
-                        <SelectItem value="oldest">Oldest First</SelectItem>
-                        <SelectItem value="popular">Most Popular</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-
-                {/* Blog Grid */}
-                {error ? (
-                  <div className="text-center py-12">
-                    <div className="text-6xl mb-4">&#x26A0;&#xFE0F;</div>
-                    <h3 className="text-xl font-bold mb-2">{error}</h3>
-                    <p className="text-muted-foreground">
-                      Please try a different category or clear your search.
-                    </p>
+                {/* Load More Button */}
+                {hasMorePosts && (
+                  <div className="my-12 text-center">
                     <Button
-                      variant="link"
-                      className="mt-4 text-primary"
-                      onClick={onClearAllFilters}
+                      onClick={loadMorePosts}
+                      disabled={loadingMore}
+                      size="lg"
                     >
-                      Clear and view all articles
+                      {loadingMore ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Loading...
+                        </>
+                      ) : (
+                        <>
+                          <Plus className="mr-2 h-4 w-4" />
+                          Load More
+                        </>
+                      )}
                     </Button>
                   </div>
-                ) : (
-                  <>
-                    {isContentLoading ? (
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                        {Array.from({ length: 4 }).map((_, i) => (
-                          <BlogCardSkeleton key={i} />
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                        {filteredPosts.map((post) => (
-                          <BlogCard key={post.id} post={post} />
-                        ))}
-                      </div>
-                    )}
-
-                    {/* Load More Button */}
-                    {hasMorePosts && !isContentLoading && (
-                      <div className="my-12 text-center">
-                        <Button
-                          onClick={loadMorePosts}
-                          disabled={loadingMore}
-                          size="lg"
-                        >
-                          {loadingMore ? (
-                            <>
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                              Loading...
-                            </>
-                          ) : (
-                            <>
-                              <Plus className="mr-2 h-4 w-4" />
-                              Load More
-                            </>
-                          )}
-                        </Button>
-                      </div>
-                    )}
-                  </>
                 )}
               </>
             )}
           </div>
 
-          {/* Sidebar */}
+          {/* Sidebar — sticky on desktop so it tracks the scroll */}
           <aside className="lg:w-1/4">
-            <BlogSidebar
-              categories={blogCategories}
-              activeCategory={activeCategory}
-              onCategoryChange={onCategoryChange}
-              isSearchActive={!!searchQuery.trim()}
-              hideCategoryNavUntilLg
-              tags={allTags}
-              onTagClick={onTagChange}
-              activeTag={activeTag}
-            />
+            <div className="lg:sticky lg:top-24">
+              <BlogSidebar
+                categories={blogCategories}
+                activeCategory={activeCategory}
+                onCategoryChange={onCategoryChange}
+                isSearchActive={!!searchQuery.trim()}
+                hideCategoryNavUntilLg
+                tags={allTags}
+                onTagClick={onTagChange}
+                activeTag={activeTag}
+              />
+            </div>
           </aside>
         </div>
       </div>

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useEffect, useRef } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { motion, useReducedMotion } from "framer-motion";
 import { toast } from "sonner";
 import { BlogGrid, BlogGridSkeleton } from "./components/BlogGrid";
 import { BlogSidebar } from "./components/BlogSidebar";
@@ -20,6 +21,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { SectionHeading } from "@/components/shared/SectionHeading";
 import { Loader2, Plus, Search, SearchX, X } from "lucide-react";
+import { entrance } from "@/lib/motion";
 import { useBlogUrlParams } from "@/hooks";
 import type { BlogCategory, PaginatedBlogsResponse } from "@/types/blog";
 
@@ -60,6 +62,8 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
   // ─── URL-synced filter actions ───
   const { onCategoryChange, onTagChange, onSearch, onClearSearch, onClearAllFilters } =
     useBlogUrlParams();
+
+  const prefersReducedMotion = useReducedMotion();
 
   // Hydrate store from server data on mount (once)
   const hydrated = useRef(false);
@@ -143,9 +147,12 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
   return (
     <main className="bg-background pt-28 md:pt-32">
       {/* Search — above filters & listing; wired via useBlogUrlParams + store */}
-      <div className="max-w-6xl mx-auto px-4 pb-8 md:pb-10">
+      <motion.div
+        {...entrance(prefersReducedMotion)}
+        className="max-w-6xl mx-auto px-4 pb-8 md:pb-10"
+      >
         <BlogSearch onSearch={onSearch} searchQuery={searchQuery} />
-      </div>
+      </motion.div>
 
       {/* Sticky filters: category tabs only below lg (desktop uses sidebar categories) */}
       <div className="sticky top-16 z-10">
@@ -213,7 +220,10 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
           {/* Main Content */}
           <div className="lg:w-3/4">
             {/* Listing header: heading + count, sort control */}
-            <div className="mb-8 flex flex-col md:flex-row justify-between md:items-end gap-4">
+            <motion.div
+              {...entrance(prefersReducedMotion, 0.1)}
+              className="mb-8 flex flex-col md:flex-row justify-between md:items-end gap-4"
+            >
               <div className="flex items-center gap-4">
                 <SectionHeading
                   eyebrow="Journal"
@@ -249,7 +259,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
                   </SelectContent>
                 </Select>
               </div>
-            </div>
+            </motion.div>
 
             {/* Blog Grid */}
             {error ? (

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useEffect, useRef } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import { toast } from "sonner";
 import { BlogGrid, BlogGridSkeleton } from "./components/BlogGrid";
@@ -19,8 +19,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/shared/EmptyState";
 import { SectionHeading } from "@/components/shared/SectionHeading";
 import { Loader2, Plus, Search, SearchX, X } from "lucide-react";
+import { getUniqueTags } from "@/lib/blogUtils";
 import { entrance } from "@/lib/motion";
 import { useBlogUrlParams } from "@/hooks";
 import type { BlogCategory, PaginatedBlogsResponse } from "@/types/blog";
@@ -33,7 +35,6 @@ export interface BlogPageProps {
 export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
 
   // ─── Store ───
   const {
@@ -94,22 +95,48 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
     fetchFilteredBlogs();
   }, [activeCategory, activeTag, searchQuery, fetchFilteredBlogs]);
 
+  // Access-denied redirect notice — reads location.search in an effect so the
+  // page stays prerenderable (see useBlogUrlParams for the same constraint).
   useEffect(() => {
-    if (searchParams.get("accessDenied") !== "1") {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("accessDenied") !== "1") {
       return;
     }
 
     toast.error("Access Denied");
 
-    const nextParams = new URLSearchParams(searchParams.toString());
-    nextParams.delete("accessDenied");
-    const nextUrl = nextParams.size > 0 ? `${pathname}?${nextParams.toString()}` : pathname;
-    router.replace(nextUrl);
-  }, [pathname, router, searchParams]);
+    params.delete("accessDenied");
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname);
+  }, [pathname, router]);
+
+  // ── First-paint data ──
+  // The store hydrates from the server payload in a post-mount effect; until
+  // then it is empty with blogsLoading=true. Render the server data directly
+  // during that window so the prerendered page and the initial visit/reload
+  // paint content instead of skeletons. URL-filtered visits briefly show the
+  // unfiltered set, then the matching fetch swaps in a skeleton.
+  const useServerData = blogsLoading && blogs.length === 0;
+
+  const displayBlogs = useServerData ? initialBlogs.blogs : blogs;
+  const displayTotalCount = useServerData ? initialBlogs.totalCount : totalCount;
+  const displayHasMore = useServerData ? initialBlogs.hasMore : hasMorePosts;
+  const displayCategories =
+    blogCategories.length > 0 ? blogCategories : initialCategories;
+  const displayTags = useMemo(
+    () => (allTags.length > 0 ? allTags : getUniqueTags(initialBlogs.blogs)),
+    [allTags, initialBlogs.blogs]
+  );
+
+  const isContentLoading =
+    (blogsLoading && !useServerData) ||
+    categoryLoading ||
+    tagLoading ||
+    searchLoading;
 
   // Sort posts client-side (derived state)
   const filteredPosts = useMemo(() => {
-    const posts = [...blogs];
+    const posts = [...displayBlogs];
 
     switch (sortBy) {
       case "oldest":
@@ -131,17 +158,14 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
     }
 
     return posts;
-  }, [blogs, sortBy]);
-
-  const isContentLoading =
-    blogsLoading || categoryLoading || tagLoading || searchLoading;
+  }, [displayBlogs, sortBy]);
 
   const hasActiveFilters =
     Boolean(searchQuery.trim()) || Boolean(activeTag) || activeCategory !== "all";
 
   const showingMeta =
     !isContentLoading && !error && filteredPosts.length > 0
-      ? `Showing ${filteredPosts.length} of ${totalCount} ${totalCount === 1 ? "post" : "posts"}`
+      ? `Showing ${filteredPosts.length} of ${displayTotalCount} ${displayTotalCount === 1 ? "post" : "posts"}`
       : undefined;
 
   return (
@@ -175,7 +199,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
           </div>
         )}
 
-        {categoriesLoading ? (
+        {categoriesLoading && displayCategories.length === 0 ? (
           <div className="lg:hidden glass py-4 border-y border-border/60">
             <div className="max-w-6xl mx-auto px-4">
               <div className="flex justify-center py-2 gap-2">
@@ -188,7 +212,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         ) : (
           <div className="lg:hidden">
             <CategoryTabs
-              categories={blogCategories}
+              categories={displayCategories}
               activeCategory={activeCategory}
               onCategoryChange={onCategoryChange}
               isSearchActive={!!searchQuery.trim()}
@@ -263,39 +287,29 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
 
             {/* Blog Grid */}
             {error ? (
-              <div className="text-center py-12">
-                <div className="text-6xl mb-4">&#x26A0;&#xFE0F;</div>
-                <h3 className="text-xl font-bold mb-2">{error}</h3>
-                <p className="text-muted-foreground">
-                  Please try a different category or clear your search.
-                </p>
-                <Button
-                  variant="link"
-                  className="mt-4 text-primary"
-                  onClick={onClearAllFilters}
-                >
-                  Clear and view all articles
-                </Button>
-              </div>
+              <EmptyState
+                icon={<span className="text-6xl">&#x26A0;&#xFE0F;</span>}
+                title={error}
+                description="Please try a different category or clear your search."
+                actionLabel="Clear and view all articles"
+                onAction={onClearAllFilters}
+              />
             ) : isContentLoading ? (
               <BlogGridSkeleton />
             ) : filteredPosts.length === 0 ? (
-              <div className="text-center py-12">
-                <SearchX className="mx-auto mb-4 h-10 w-10 text-muted-foreground" />
-                <h3 className="text-xl font-bold mb-2">No articles found</h3>
-                <p className="text-muted-foreground">
-                  Nothing matches the current filters.
-                </p>
-                {hasActiveFilters && (
-                  <Button
-                    variant="link"
-                    className="mt-4 text-primary"
-                    onClick={onClearAllFilters}
-                  >
-                    Clear and view all articles
-                  </Button>
-                )}
-              </div>
+              <EmptyState
+                icon={<SearchX className="h-10 w-10" />}
+                title="No articles found"
+                description={
+                  hasActiveFilters
+                    ? "Nothing matches the current filters."
+                    : "No articles have been published yet — check back soon."
+                }
+                actionLabel={
+                  hasActiveFilters ? "Clear and view all articles" : undefined
+                }
+                onAction={hasActiveFilters ? onClearAllFilters : undefined}
+              />
             ) : (
               <>
                 <BlogGrid
@@ -304,7 +318,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
                 />
 
                 {/* Load More Button */}
-                {hasMorePosts && (
+                {displayHasMore && (
                   <div className="my-12 text-center">
                     <Button
                       onClick={loadMorePosts}
@@ -333,12 +347,12 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
           <aside className="lg:w-1/4">
             <div className="lg:sticky lg:top-24">
               <BlogSidebar
-                categories={blogCategories}
+                categories={displayCategories}
                 activeCategory={activeCategory}
                 onCategoryChange={onCategoryChange}
                 isSearchActive={!!searchQuery.trim()}
                 hideCategoryNavUntilLg
-                tags={allTags}
+                tags={displayTags}
                 onTagClick={onTagChange}
                 activeTag={activeTag}
               />

--- a/src/features/blog/components/BlogCard.tsx
+++ b/src/features/blog/components/BlogCard.tsx
@@ -4,19 +4,23 @@ import Link from "next/link";
 import {
   getAuthorName,
   getAuthorImage,
+  getPostImageSrc,
+  getReadTime,
   formatDate,
-  getSafeImageSrc,
 } from "@/lib/blogUtils";
 import { Card, CardContent } from "@/components/ui/card";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export type BlogCardVariant = "default" | "featured";
+export type BlogCardVariant = "default" | "featured" | "compact";
 
 interface BlogCardProps {
   post: BlogPost;
-  /** "featured" spans two grid columns with a horizontal media/content split. */
+  /**
+   * "featured" — horizontal media/content split for a full-width slot.
+   * "compact" — cover + title + read time, for dense grids (related posts).
+   */
   variant?: BlogCardVariant;
 }
 
@@ -27,11 +31,30 @@ function getCategoryName(category: BlogPost["category"]): string {
   return category.name || "Uncategorized";
 }
 
+/** Mono glass chip rendered over the cover image. */
+function CoverChip({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "glass-scrim absolute flex items-center font-mono text-[10px] uppercase tracking-[0.12em]",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
 export function BlogCard({ post, variant = "default" }: BlogCardProps) {
   const authorName = getAuthorName(post.author);
-  const categoryName = getCategoryName(post.category);
-  const imageSrc = getSafeImageSrc(post.imageUrl, "/images/blog/placeholder.jpg");
   const featured = variant === "featured";
+  const compact = variant === "compact";
 
   return (
     <article className="group relative h-full">
@@ -51,75 +74,84 @@ export function BlogCard({ post, variant = "default" }: BlogCardProps) {
           )}
         >
           <Image
-            src={imageSrc}
+            src={getPostImageSrc(post)}
             alt={post.title}
             fill
             sizes={
               featured
                 ? "(max-width: 768px) 100vw, 50vw"
-                : "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                : compact
+                  ? "(max-width: 768px) 100vw, 25vw"
+                  : "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             }
             className="object-cover transition-transform duration-300 motion-safe:group-hover:scale-[1.03]"
           />
           {post.isNew && (
-            <span className="glass-scrim absolute right-3 top-3 flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em]">
+            <CoverChip className="right-3 top-3 gap-1.5 rounded-full px-2.5 py-1">
               <span
                 aria-hidden
                 className="h-1.5 w-1.5 rounded-full bg-emerald-400 motion-safe:animate-pulse-soft"
               />
               New
-            </span>
+            </CoverChip>
           )}
           {/* Meta strip — category + read time over the image */}
-          <div className="glass-scrim absolute inset-x-3 bottom-3 flex items-center justify-between gap-3 rounded-lg px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em]">
-            <span className="truncate">{categoryName}</span>
-            <span className="shrink-0">{post.readTime || "5 min read"}</span>
-          </div>
+          <CoverChip className="inset-x-3 bottom-3 justify-between gap-3 rounded-lg px-3 py-1.5">
+            <span className="truncate">{getCategoryName(post.category)}</span>
+            <span className="shrink-0">{getReadTime(post)}</span>
+          </CoverChip>
         </div>
 
         {/* Content */}
         <CardContent
           className={cn(
             "flex flex-1 flex-col gap-3 p-5",
-            featured && "md:justify-center md:p-7"
+            featured && "md:justify-center md:p-7",
+            compact && "gap-2 p-4"
           )}
         >
           <h3
             className={cn(
-              "text-lg font-bold leading-snug text-foreground transition-colors duration-200 group-hover:text-primary",
-              featured && "md:text-2xl"
+              "font-bold leading-snug text-foreground transition-colors duration-200 group-hover:text-primary",
+              featured && "text-lg md:text-2xl",
+              compact && "line-clamp-2 text-base font-semibold",
+              !featured && !compact && "text-lg"
             )}
           >
             {post.title}
           </h3>
 
-          <p
-            className={cn(
-              "line-clamp-3 flex-1 text-sm leading-relaxed text-muted-foreground",
-              featured && "md:flex-none md:text-base"
-            )}
-          >
-            {post.description}
-          </p>
+          {!compact && (
+            <p
+              className={cn(
+                "line-clamp-3 flex-1 text-sm leading-relaxed text-muted-foreground",
+                featured && "md:flex-none md:text-base"
+              )}
+            >
+              {post.description}
+            </p>
+          )}
 
           {/* Footer */}
-          <div className="mt-auto flex items-center justify-between border-t border-border pt-4">
-            <div className="flex items-center gap-2.5">
-              <Avatar className="h-7 w-7">
-                <AvatarImage src={getAuthorImage(post)} alt={authorName} />
-                <AvatarFallback className="text-xs">
-                  {authorName.charAt(0)}
-                </AvatarFallback>
-              </Avatar>
-              <span className="text-meta">{formatDate(post.createdAt)}</span>
+          {!compact && (
+            <div className="mt-auto flex items-center justify-between border-t border-border pt-4">
+              <div className="flex items-center gap-2.5">
+                <Avatar className="h-7 w-7">
+                  <AvatarImage src={getAuthorImage(post)} alt={authorName} />
+                  <AvatarFallback className="text-xs">
+                    {authorName.charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-meta">{formatDate(post.createdAt)}</span>
+              </div>
+              <span
+                aria-hidden
+                className="flex h-8 w-8 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors duration-300 group-hover:border-primary group-hover:bg-primary/10 group-hover:text-primary"
+              >
+                <ArrowRight className="h-4 w-4 transition-transform duration-300 motion-safe:group-hover:translate-x-0.5" />
+              </span>
             </div>
-            <span
-              aria-hidden
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors duration-300 group-hover:border-primary group-hover:bg-primary/10 group-hover:text-primary"
-            >
-              <ArrowRight className="h-4 w-4 transition-transform duration-300 motion-safe:group-hover:translate-x-0.5" />
-            </span>
-          </div>
+          )}
         </CardContent>
       </Card>
 

--- a/src/features/blog/components/BlogCard.tsx
+++ b/src/features/blog/components/BlogCard.tsx
@@ -39,7 +39,7 @@ export function BlogCard({ post, variant = "default" }: BlogCardProps) {
         className={cn(
           "h-full gap-0 overflow-hidden py-0 transition-all duration-300",
           "group-hover:ring-primary/40 group-hover:shadow-[0_16px_40px_-18px] group-hover:shadow-primary/35",
-          "motion-safe:group-hover:-translate-y-0.5",
+          "motion-safe:group-hover:-translate-y-0.5 motion-safe:group-active:scale-[0.99]",
           featured && "md:grid md:grid-cols-2"
         )}
       >

--- a/src/features/blog/components/BlogCard.tsx
+++ b/src/features/blog/components/BlogCard.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { BlogPost } from "@/types/blog";
 import Image from "next/image";
 import Link from "next/link";
@@ -10,12 +8,16 @@ import {
   getSafeImageSrc,
 } from "@/lib/blogUtils";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Bookmark, Clock } from "lucide-react";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type BlogCardVariant = "default" | "featured";
 
 interface BlogCardProps {
   post: BlogPost;
+  /** "featured" spans two grid columns with a horizontal media/content split. */
+  variant?: BlogCardVariant;
 }
 
 // Helper: get category name from string or object
@@ -25,89 +27,108 @@ function getCategoryName(category: BlogPost["category"]): string {
   return category.name || "Uncategorized";
 }
 
-export function BlogCard({ post }: BlogCardProps) {
+export function BlogCard({ post, variant = "default" }: BlogCardProps) {
   const authorName = getAuthorName(post.author);
   const categoryName = getCategoryName(post.category);
   const imageSrc = getSafeImageSrc(post.imageUrl, "/images/blog/placeholder.jpg");
+  const featured = variant === "featured";
 
   return (
-    <article>
-      <Card className="overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 group h-full flex flex-col">
-        {/* Image */}
-        <div className="relative">
-          <div className="relative w-full h-48 overflow-hidden">
-            <Image
-              src={imageSrc}
-              alt={post.title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              className="object-cover transition-transform duration-700 group-hover:scale-110"
-            />
-          </div>
-          {post.isNew && (
-            <Badge className="absolute top-2 right-2 bg-primary text-primary-foreground font-bold text-xs">
-              NEW
-            </Badge>
+    <article className="group relative h-full">
+      <Card
+        className={cn(
+          "h-full gap-0 overflow-hidden py-0 transition-all duration-300",
+          "group-hover:ring-primary/40 group-hover:shadow-[0_16px_40px_-18px] group-hover:shadow-primary/35",
+          "motion-safe:group-hover:-translate-y-0.5",
+          featured && "md:grid md:grid-cols-2"
+        )}
+      >
+        {/* Cover */}
+        <div
+          className={cn(
+            "relative aspect-video overflow-hidden",
+            featured && "md:aspect-auto md:h-full md:min-h-64"
           )}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
+        >
+          <Image
+            src={imageSrc}
+            alt={post.title}
+            fill
+            sizes={
+              featured
+                ? "(max-width: 768px) 100vw, 50vw"
+                : "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            }
+            className="object-cover transition-transform duration-300 motion-safe:group-hover:scale-[1.03]"
+          />
+          {post.isNew && (
+            <span className="glass-scrim absolute right-3 top-3 flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em]">
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 rounded-full bg-emerald-400 motion-safe:animate-pulse-soft"
+              />
+              New
+            </span>
+          )}
+          {/* Meta strip — category + read time over the image */}
+          <div className="glass-scrim absolute inset-x-3 bottom-3 flex items-center justify-between gap-3 rounded-lg px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em]">
+            <span className="truncate">{categoryName}</span>
+            <span className="shrink-0">{post.readTime || "5 min read"}</span>
+          </div>
         </div>
 
         {/* Content */}
-        <CardContent className="p-5 flex flex-col flex-1">
-          {/* Tags */}
-          <div className="flex flex-wrap gap-2 mb-3">
-            <Badge variant="secondary" className="text-xs">
-              <Bookmark className="h-3 w-3 mr-1" />
-              {categoryName}
-            </Badge>
-            {post.tags.slice(0, 1).map((tag) => (
-              <Badge key={tag} variant="outline" className="text-xs">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-
-          {/* Title */}
-          <h3 className="text-xl font-bold mb-3 text-foreground group-hover:text-primary transition-colors">
-            <Link href={`/blog/${post.slug}`} className="hover:underline">
-              {post.title}
-            </Link>
+        <CardContent
+          className={cn(
+            "flex flex-1 flex-col gap-3 p-5",
+            featured && "md:justify-center md:p-7"
+          )}
+        >
+          <h3
+            className={cn(
+              "text-lg font-bold leading-snug text-foreground transition-colors duration-200 group-hover:text-primary",
+              featured && "md:text-2xl"
+            )}
+          >
+            {post.title}
           </h3>
 
-          {/* Description */}
-          <p className="text-muted-foreground mb-4 leading-relaxed overflow-hidden max-h-[4.5rem] flex-1">
+          <p
+            className={cn(
+              "line-clamp-3 flex-1 text-sm leading-relaxed text-muted-foreground",
+              featured && "md:flex-none md:text-base"
+            )}
+          >
             {post.description}
           </p>
 
           {/* Footer */}
-          <div className="flex justify-between items-center border-t border-border pt-4 mt-auto">
-            <div className="flex items-center gap-2">
-              <Avatar className="h-8 w-8 border border-primary">
+          <div className="mt-auto flex items-center justify-between border-t border-border pt-4">
+            <div className="flex items-center gap-2.5">
+              <Avatar className="h-7 w-7">
                 <AvatarImage src={getAuthorImage(post)} alt={authorName} />
                 <AvatarFallback className="text-xs">
                   {authorName.charAt(0)}
                 </AvatarFallback>
               </Avatar>
-              <div>
-                <p className="text-xs text-muted-foreground">
-                  {formatDate(post.createdAt)}
-                </p>
-                <p className="text-xs text-muted-foreground/70 flex items-center gap-1">
-                  <Clock className="h-3 w-3" />
-                  {post.readTime || "5 min read"}
-                </p>
-              </div>
+              <span className="text-meta">{formatDate(post.createdAt)}</span>
             </div>
-
-            <Link
-              href={`/blog/${post.slug}`}
-              className="text-primary hover:text-primary/80 text-sm font-medium transition-colors"
+            <span
+              aria-hidden
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors duration-300 group-hover:border-primary group-hover:bg-primary/10 group-hover:text-primary"
             >
-              Read
-            </Link>
+              <ArrowRight className="h-4 w-4 transition-transform duration-300 motion-safe:group-hover:translate-x-0.5" />
+            </span>
           </div>
         </CardContent>
       </Card>
+
+      {/* Stretched link — the whole card is one target */}
+      <Link
+        href={`/blog/${post.slug}`}
+        aria-label={post.title}
+        className="absolute inset-0 z-10 rounded-xl"
+      />
     </article>
   );
 }

--- a/src/features/blog/components/BlogGrid.tsx
+++ b/src/features/blog/components/BlogGrid.tsx
@@ -1,14 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import type { BlogPost } from "@/types/blog";
 import { BlogCard } from "./BlogCard";
 import { BlogCardSkeleton } from "@/components/shared/LoadingStates";
+import { DURATION, EASE_OUT, SPRING_GENTLE } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 const GRID_CLASSES = "grid grid-cols-1 gap-8 md:grid-cols-2";
 
-/** Maximum stagger delay so long lists don't trickle in forever. */
+/** Maximum stagger delay so long batches don't trickle in forever. */
 const MAX_STAGGER_DELAY = 0.4;
 
 export function BlogGridSkeleton({ count = 4 }: { count?: number }) {
@@ -28,26 +30,49 @@ interface BlogGridProps {
 }
 
 /**
- * Post grid with a staggered fade-rise entrance. Owns all layout concerns
+ * Post grid with batch-aware choreography. Owns all layout concerns
  * (columns, spans); BlogCard stays grid-agnostic.
+ *
+ * Entrances only run when a card mounts, so each batch (initial load,
+ * Load More append) staggers from zero while cards already on screen stay
+ * put; re-sorting glides existing cards to their new positions via layout
+ * animation.
  */
 export function BlogGrid({ posts, featureFirst = false }: BlogGridProps) {
   const prefersReducedMotion = useReducedMotion();
+
+  // Entrance delay per post, assigned by position within the batch that
+  // introduced it — state adjusted during render so delays are ready on
+  // each batch's mount pass.
+  const [delayById, setDelayById] = useState<ReadonlyMap<string, number>>(
+    new Map()
+  );
+  const unseen = posts.filter((post) => !delayById.has(post.id));
+  if (unseen.length > 0) {
+    const next = new Map(delayById);
+    unseen.forEach((post, batchIndex) => {
+      next.set(post.id, Math.min(batchIndex * 0.06, MAX_STAGGER_DELAY));
+    });
+    setDelayById(next);
+  }
 
   return (
     <div className={GRID_CLASSES}>
       {posts.map((post, index) => {
         const featured = featureFirst && index === 0;
+
         return (
           <motion.div
             key={post.id}
+            layout={prefersReducedMotion ? false : "position"}
             className={cn("h-full", featured && "md:col-span-2")}
-            initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{
-              duration: 0.35,
-              ease: "easeOut",
-              delay: Math.min(index * 0.05, MAX_STAGGER_DELAY),
+              layout: SPRING_GENTLE,
+              duration: DURATION.base,
+              ease: EASE_OUT,
+              delay: delayById.get(post.id) ?? 0,
             }}
           >
             <BlogCard post={post} variant={featured ? "featured" : "default"} />

--- a/src/features/blog/components/BlogGrid.tsx
+++ b/src/features/blog/components/BlogGrid.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import type { BlogPost } from "@/types/blog";
+import { BlogCard } from "./BlogCard";
+import { BlogCardSkeleton } from "@/components/shared/LoadingStates";
+import { cn } from "@/lib/utils";
+
+const GRID_CLASSES = "grid grid-cols-1 gap-8 md:grid-cols-2";
+
+/** Maximum stagger delay so long lists don't trickle in forever. */
+const MAX_STAGGER_DELAY = 0.4;
+
+export function BlogGridSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className={GRID_CLASSES}>
+      {Array.from({ length: count }).map((_, i) => (
+        <BlogCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+interface BlogGridProps {
+  posts: BlogPost[];
+  /** Render the first post full-width as a featured card. */
+  featureFirst?: boolean;
+}
+
+/**
+ * Post grid with a staggered fade-rise entrance. Owns all layout concerns
+ * (columns, spans); BlogCard stays grid-agnostic.
+ */
+export function BlogGrid({ posts, featureFirst = false }: BlogGridProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <div className={GRID_CLASSES}>
+      {posts.map((post, index) => {
+        const featured = featureFirst && index === 0;
+        return (
+          <motion.div
+            key={post.id}
+            className={cn("h-full", featured && "md:col-span-2")}
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{
+              duration: 0.35,
+              ease: "easeOut",
+              delay: Math.min(index * 0.05, MAX_STAGGER_DELAY),
+            }}
+          >
+            <BlogCard post={post} variant={featured ? "featured" : "default"} />
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/blog/components/BlogSearch.tsx
+++ b/src/features/blog/components/BlogSearch.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Search } from "lucide-react";
+import { ArrowRight, Search } from "lucide-react";
 
 interface BlogSearchProps {
   onSearch: (query: string) => void;
@@ -14,55 +14,48 @@ interface BlogSearchProps {
 export function BlogSearch({
   onSearch,
   searchQuery: externalSearchQuery = "",
-  placeholder = "Search articles by keyword or topic...",
+  placeholder = "Search articles by keyword or topic…",
 }: BlogSearchProps) {
   const [query, setQuery] = useState(externalSearchQuery);
-  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Sync internal state with external search query changes
-  useEffect(() => {
+  // Sync internal state when the external query changes (URL navigation,
+  // clear-search) — adjusted during render instead of via an effect.
+  const [prevExternalQuery, setPrevExternalQuery] = useState(externalSearchQuery);
+  if (externalSearchQuery !== prevExternalQuery) {
+    setPrevExternalQuery(externalSearchQuery);
     setQuery(externalSearchQuery);
-  }, [externalSearchQuery]);
+  }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current);
-      debounceTimeoutRef.current = null;
-    }
     onSearch(query.trim());
   };
 
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceTimeoutRef.current) {
-        clearTimeout(debounceTimeoutRef.current);
-      }
-    };
-  }, []);
-
   return (
-    <div className="max-w-2xl mx-auto relative">
-      <form onSubmit={handleSubmit}>
-        <div className="flex rounded-lg overflow-hidden shadow-lg border border-border focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition-all duration-300">
-          <Input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={placeholder}
-            className="flex-grow border-0 rounded-none py-6 px-5 bg-background/80 backdrop-blur-sm focus-visible:ring-0 focus-visible:ring-offset-0"
-          />
-          <Button
-            type="submit"
-            size="lg"
-            className="rounded-none px-6"
-            title="Search"
-          >
-            <Search className="h-5 w-5" />
-          </Button>
-        </div>
-      </form>
-    </div>
+    <form
+      onSubmit={handleSubmit}
+      role="search"
+      className="relative mx-auto max-w-2xl"
+    >
+      <Search
+        aria-hidden
+        className="pointer-events-none absolute left-5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder={placeholder}
+        className="h-12 rounded-full border-border bg-card/60 pl-12 pr-14 text-base shadow-none backdrop-blur-md transition-[border-color,box-shadow] duration-200 hover:border-primary/40 focus-visible:border-primary focus-visible:ring-primary/30"
+      />
+      <Button
+        type="submit"
+        size="icon"
+        aria-label="Search"
+        className="absolute right-1.5 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full"
+      >
+        <ArrowRight className="h-4 w-4" />
+      </Button>
+    </form>
   );
 }

--- a/src/features/blog/components/BlogSearch.tsx
+++ b/src/features/blog/components/BlogSearch.tsx
@@ -52,7 +52,7 @@ export function BlogSearch({
         type="submit"
         size="icon"
         aria-label="Search"
-        className="absolute right-1.5 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full transition-transform motion-safe:active:scale-90"
+        className="pressable absolute right-1.5 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full transition-transform"
       >
         <ArrowRight className="h-4 w-4" />
       </Button>

--- a/src/features/blog/components/BlogSearch.tsx
+++ b/src/features/blog/components/BlogSearch.tsx
@@ -52,7 +52,7 @@ export function BlogSearch({
         type="submit"
         size="icon"
         aria-label="Search"
-        className="absolute right-1.5 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full"
+        className="absolute right-1.5 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full transition-transform motion-safe:active:scale-90"
       >
         <ArrowRight className="h-4 w-4" />
       </Button>

--- a/src/features/blog/components/BlogSidebar.tsx
+++ b/src/features/blog/components/BlogSidebar.tsx
@@ -40,10 +40,7 @@ export function BlogSidebar({
         >
         <Card>
           <CardHeader>
-            <h3 className="font-bold flex items-center">
-              <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-              Categories
-            </h3>
+            <h3 className="text-eyebrow">Categories</h3>
           </CardHeader>
           <CardContent>
             <CategoryTabs
@@ -61,10 +58,7 @@ export function BlogSidebar({
       {/* Topic Cloud */}
       <Card>
         <CardHeader>
-          <h3 className="font-bold flex items-center">
-            <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-            Topic Cloud
-          </h3>
+          <h3 className="text-eyebrow">Topic Cloud</h3>
         </CardHeader>
         <CardContent>
           <div className="flex flex-wrap gap-2">

--- a/src/features/blog/components/BlogSidebar.tsx
+++ b/src/features/blog/components/BlogSidebar.tsx
@@ -68,6 +68,7 @@ export function BlogSidebar({
                 <button
                   key={`${tag}-${idx}`}
                   onClick={() => onTagClick?.(tag)}
+                  className="transition-transform duration-150 motion-safe:active:scale-95"
                 >
                   <Badge
                     variant={isActive ? "default" : "secondary"}

--- a/src/features/blog/components/BlogSidebar.tsx
+++ b/src/features/blog/components/BlogSidebar.tsx
@@ -68,7 +68,7 @@ export function BlogSidebar({
                 <button
                   key={`${tag}-${idx}`}
                   onClick={() => onTagClick?.(tag)}
-                  className="transition-transform duration-150 motion-safe:active:scale-95"
+                  className="pressable transition-transform duration-150"
                 >
                   <Badge
                     variant={isActive ? "default" : "secondary"}

--- a/src/features/blog/components/CategoryTabs.tsx
+++ b/src/features/blog/components/CategoryTabs.tsx
@@ -102,12 +102,12 @@ export function CategoryTabs({
   }
 
   return (
-    <div className="bg-muted/50 py-4 border-y border-border/50">
+    <div className="glass border-y border-border/60 py-3">
       <div className="max-w-6xl mx-auto px-4">
         <ScrollArea className="w-full">
           <div
             ref={scrollRef}
-            className="flex gap-2 md:gap-4 justify-start md:justify-center min-w-max pb-2"
+            className="flex gap-2 md:gap-3 justify-start md:justify-center min-w-max pb-2"
           >
             {allCategories.map((category) => {
               const categoryId = category.id;
@@ -119,19 +119,17 @@ export function CategoryTabs({
                   key={categoryId}
                   data-category={categoryId}
                   onClick={() => onCategoryChange(categoryId)}
-                  className={`
-                    px-4 py-2 rounded-full font-medium transition-all duration-300 whitespace-nowrap flex-shrink-0 flex items-center gap-2
-                    ${
-                      isActive
-                        ? "bg-primary text-primary-foreground shadow-lg"
-                        : isSearchActive
-                        ? "bg-muted border border-border text-muted-foreground opacity-60"
-                        : "bg-card border border-border hover:border-primary text-foreground hover:shadow-md"
-                    }
-                  `}
+                  className={cn(
+                    "flex flex-shrink-0 items-center gap-2 whitespace-nowrap rounded-full border px-4 py-2 text-sm font-medium transition-colors duration-200",
+                    isActive
+                      ? "border-primary bg-primary text-primary-foreground shadow-[0_0_16px] shadow-primary/40"
+                      : isSearchActive
+                        ? "border-border bg-muted text-muted-foreground opacity-60"
+                        : "border-border bg-card/60 text-foreground hover:border-primary/50 hover:text-primary"
+                  )}
                 >
                   {categoryId === "all" && (
-                    <LayoutGrid className="h-4 w-4" />
+                    <LayoutGrid className="h-4 w-4" aria-hidden />
                   )}
                   {category.name}
                 </button>

--- a/src/features/blog/components/CategoryTabs.tsx
+++ b/src/features/blog/components/CategoryTabs.tsx
@@ -19,24 +19,76 @@ interface CategoryTabsProps {
   variant?: CategoryTabsVariant;
 }
 
-/**
- * Active-state fill that glides between items via shared layout animation.
- * Scoped by instance so multiple tab sets on one page never cross-animate.
- */
-function ActiveIndicator({
-  layoutId,
-  className,
-}: {
-  layoutId: string | undefined;
-  className: string;
-}) {
+/** Per-variant presentation of a category item and its active indicator. */
+const VARIANT_STYLES: Record<
+  CategoryTabsVariant,
+  { button: string; inactive: string; indicator: string }
+> = {
+  horizontal: {
+    button:
+      "flex-shrink-0 whitespace-nowrap rounded-full border px-4 py-2 justify-center",
+    inactive:
+      "border-border bg-card/60 text-foreground hover:border-primary/50 hover:text-primary",
+    indicator: "rounded-full bg-primary shadow-[0_0_16px] shadow-primary/40",
+  },
+  sidebar: {
+    button: "w-full rounded-lg border px-3 py-2.5 text-left",
+    inactive:
+      "border-transparent text-foreground hover:border-primary/30 hover:bg-primary/5 hover:text-primary",
+    indicator: "rounded-lg bg-primary shadow-sm",
+  },
+};
+
+interface CategoryTabButtonProps {
+  category: BlogCategory;
+  variant: CategoryTabsVariant;
+  isActive: boolean;
+  isSearchActive: boolean;
+  /** Shared layout id for the gliding active fill; undefined disables it. */
+  indicatorLayoutId: string | undefined;
+  onClick: () => void;
+}
+
+function CategoryTabButton({
+  category,
+  variant,
+  isActive,
+  isSearchActive,
+  indicatorLayoutId,
+  onClick,
+}: CategoryTabButtonProps) {
+  const styles = VARIANT_STYLES[variant];
+
   return (
-    <motion.span
-      aria-hidden
-      layoutId={layoutId}
-      transition={SPRING_SNAPPY}
-      className={className}
-    />
+    <button
+      type="button"
+      data-category={category.id}
+      onClick={onClick}
+      className={cn(
+        "pressable relative flex items-center gap-2 text-sm font-medium transition-all duration-200",
+        styles.button,
+        isActive
+          ? "border-transparent text-primary-foreground"
+          : isSearchActive
+            ? "border-border bg-muted/50 text-muted-foreground opacity-60"
+            : styles.inactive
+      )}
+    >
+      {isActive && (
+        <motion.span
+          aria-hidden
+          layoutId={indicatorLayoutId}
+          transition={SPRING_SNAPPY}
+          className={cn("absolute inset-0", styles.indicator)}
+        />
+      )}
+      <span className="relative z-10 flex items-center gap-2">
+        {category.id === "all" && (
+          <LayoutGrid className="h-4 w-4 shrink-0" aria-hidden />
+        )}
+        <span>{category.name}</span>
+      </span>
+    </button>
   );
 }
 
@@ -96,43 +148,22 @@ export function CategoryTabs({
     }
   }, [activeCategory, variant]);
 
+  const renderButton = (category: BlogCategory) => (
+    <CategoryTabButton
+      key={category.id}
+      category={category}
+      variant={variant}
+      isActive={activeCategory === category.id && !isSearchActive}
+      isSearchActive={isSearchActive}
+      indicatorLayoutId={indicatorLayoutId}
+      onClick={() => onCategoryChange(category.id)}
+    />
+  );
+
   if (variant === "sidebar") {
     return (
       <nav aria-label="Blog categories" className="flex flex-col gap-1">
-        {allCategories.map((category) => {
-          const categoryId = category.id;
-          const isActive =
-            activeCategory === categoryId && !isSearchActive;
-
-          return (
-            <button
-              key={categoryId}
-              type="button"
-              onClick={() => onCategoryChange(categoryId)}
-              className={cn(
-                "relative flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-all duration-200 motion-safe:active:scale-[0.98]",
-                isActive
-                  ? "text-primary-foreground"
-                  : isSearchActive
-                    ? "border border-border bg-muted/50 text-muted-foreground opacity-70"
-                    : "border border-transparent text-foreground hover:border-primary/30 hover:bg-primary/5 hover:text-primary"
-              )}
-            >
-              {isActive && (
-                <ActiveIndicator
-                  layoutId={indicatorLayoutId}
-                  className="absolute inset-0 rounded-lg bg-primary shadow-sm"
-                />
-              )}
-              <span className="relative z-10 flex items-center gap-2">
-                {categoryId === "all" && (
-                  <LayoutGrid className="h-4 w-4 shrink-0" aria-hidden />
-                )}
-                <span>{category.name}</span>
-              </span>
-            </button>
-          );
-        })}
+        {allCategories.map(renderButton)}
       </nav>
     );
   }
@@ -145,40 +176,7 @@ export function CategoryTabs({
             ref={scrollRef}
             className="flex gap-2 md:gap-3 justify-start md:justify-center min-w-max pb-2"
           >
-            {allCategories.map((category) => {
-              const categoryId = category.id;
-              const isActive =
-                activeCategory === categoryId && !isSearchActive;
-
-              return (
-                <button
-                  key={categoryId}
-                  data-category={categoryId}
-                  onClick={() => onCategoryChange(categoryId)}
-                  className={cn(
-                    "relative flex flex-shrink-0 items-center gap-2 whitespace-nowrap rounded-full border px-4 py-2 text-sm font-medium transition-all duration-200 motion-safe:active:scale-[0.97]",
-                    isActive
-                      ? "border-transparent text-primary-foreground"
-                      : isSearchActive
-                        ? "border-border bg-muted text-muted-foreground opacity-60"
-                        : "border-border bg-card/60 text-foreground hover:border-primary/50 hover:text-primary"
-                  )}
-                >
-                  {isActive && (
-                    <ActiveIndicator
-                      layoutId={indicatorLayoutId}
-                      className="absolute inset-0 rounded-full bg-primary shadow-[0_0_16px] shadow-primary/40"
-                    />
-                  )}
-                  <span className="relative z-10 flex items-center gap-2">
-                    {categoryId === "all" && (
-                      <LayoutGrid className="h-4 w-4" aria-hidden />
-                    )}
-                    {category.name}
-                  </span>
-                </button>
-              );
-            })}
+            {allCategories.map(renderButton)}
           </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>

--- a/src/features/blog/components/CategoryTabs.tsx
+++ b/src/features/blog/components/CategoryTabs.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useMemo, useRef, useEffect } from "react";
+import { useMemo, useRef, useEffect, useId } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { BlogCategory } from "@/types/blog";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { LayoutGrid } from "lucide-react";
+import { SPRING_SNAPPY } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 export type CategoryTabsVariant = "horizontal" | "sidebar";
@@ -17,6 +19,27 @@ interface CategoryTabsProps {
   variant?: CategoryTabsVariant;
 }
 
+/**
+ * Active-state fill that glides between items via shared layout animation.
+ * Scoped by instance so multiple tab sets on one page never cross-animate.
+ */
+function ActiveIndicator({
+  layoutId,
+  className,
+}: {
+  layoutId: string | undefined;
+  className: string;
+}) {
+  return (
+    <motion.span
+      aria-hidden
+      layoutId={layoutId}
+      transition={SPRING_SNAPPY}
+      className={className}
+    />
+  );
+}
+
 export function CategoryTabs({
   categories,
   activeCategory,
@@ -26,6 +49,11 @@ export function CategoryTabs({
 }: CategoryTabsProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const mountedRef = useRef(false);
+  const prefersReducedMotion = useReducedMotion();
+  const instanceId = useId();
+  const indicatorLayoutId = prefersReducedMotion
+    ? undefined
+    : `${instanceId}-active-category`;
 
   // All categories including "All Topics"
   const allCategories = useMemo(
@@ -82,18 +110,26 @@ export function CategoryTabs({
               type="button"
               onClick={() => onCategoryChange(categoryId)}
               className={cn(
-                "flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors",
+                "relative flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-all duration-200 motion-safe:active:scale-[0.98]",
                 isActive
-                  ? "bg-primary text-primary-foreground shadow-sm"
+                  ? "text-primary-foreground"
                   : isSearchActive
                     ? "border border-border bg-muted/50 text-muted-foreground opacity-70"
                     : "border border-transparent text-foreground hover:border-primary/30 hover:bg-primary/5 hover:text-primary"
               )}
             >
-              {categoryId === "all" && (
-                <LayoutGrid className="h-4 w-4 shrink-0" aria-hidden />
+              {isActive && (
+                <ActiveIndicator
+                  layoutId={indicatorLayoutId}
+                  className="absolute inset-0 rounded-lg bg-primary shadow-sm"
+                />
               )}
-              <span>{category.name}</span>
+              <span className="relative z-10 flex items-center gap-2">
+                {categoryId === "all" && (
+                  <LayoutGrid className="h-4 w-4 shrink-0" aria-hidden />
+                )}
+                <span>{category.name}</span>
+              </span>
             </button>
           );
         })}
@@ -120,18 +156,26 @@ export function CategoryTabs({
                   data-category={categoryId}
                   onClick={() => onCategoryChange(categoryId)}
                   className={cn(
-                    "flex flex-shrink-0 items-center gap-2 whitespace-nowrap rounded-full border px-4 py-2 text-sm font-medium transition-colors duration-200",
+                    "relative flex flex-shrink-0 items-center gap-2 whitespace-nowrap rounded-full border px-4 py-2 text-sm font-medium transition-all duration-200 motion-safe:active:scale-[0.97]",
                     isActive
-                      ? "border-primary bg-primary text-primary-foreground shadow-[0_0_16px] shadow-primary/40"
+                      ? "border-transparent text-primary-foreground"
                       : isSearchActive
                         ? "border-border bg-muted text-muted-foreground opacity-60"
                         : "border-border bg-card/60 text-foreground hover:border-primary/50 hover:text-primary"
                   )}
                 >
-                  {categoryId === "all" && (
-                    <LayoutGrid className="h-4 w-4" aria-hidden />
+                  {isActive && (
+                    <ActiveIndicator
+                      layoutId={indicatorLayoutId}
+                      className="absolute inset-0 rounded-full bg-primary shadow-[0_0_16px] shadow-primary/40"
+                    />
                   )}
-                  {category.name}
+                  <span className="relative z-10 flex items-center gap-2">
+                    {categoryId === "all" && (
+                      <LayoutGrid className="h-4 w-4" aria-hidden />
+                    )}
+                    {category.name}
+                  </span>
                 </button>
               );
             })}

--- a/src/features/blog/components/ShareArticle.tsx
+++ b/src/features/blog/components/ShareArticle.tsx
@@ -8,27 +8,37 @@ import {
 } from "@/components/ui/tooltip";
 import { Facebook, Twitter, Linkedin, Link2, Check } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 interface ShareArticleProps {
   title: string;
   url: string;
   className?: string;
-  inline?: boolean;
 }
 
-export function ShareArticle({
-  title,
-  url,
-  className = "",
-  inline = false,
-}: ShareArticleProps) {
+const shareButtonClasses =
+  "inline-flex h-10 w-10 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors duration-200 hover:border-primary hover:bg-primary/10 hover:text-primary";
+
+export function ShareArticle({ title, url, className }: ShareArticleProps) {
   const [copied, setCopied] = useState(false);
 
-  const shareLinks = {
-    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
-    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
-  };
+  const shareLinks = [
+    {
+      label: "Share on Facebook",
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+      Icon: Facebook,
+    },
+    {
+      label: "Share on X",
+      href: `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`,
+      Icon: Twitter,
+    },
+    {
+      label: "Share on LinkedIn",
+      href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+      Icon: Linkedin,
+    },
+  ] as const;
 
   const handleCopyLink = async () => {
     try {
@@ -42,71 +52,27 @@ export function ShareArticle({
   };
 
   return (
-    <div
-      className={
-        inline
-          ? className
-          : `bg-card rounded-xl p-6 ${className}`
-      }
-    >
-      <h3 className="font-bold mb-4 flex items-center">
-        {!inline && (
-          <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-        )}
-        Share This Article
-      </h3>
-
-      <div className="flex gap-3">
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <a
-                href={shareLinks.facebook}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Share on Facebook"
-                className="inline-flex items-center justify-center rounded-full h-12 w-12 bg-[#1877F2] text-white hover:bg-[#1877F2]/80 transition-colors"
-              >
-                <Facebook className="h-5 w-5" />
-              </a>
-            }
-          />
-          <TooltipContent>Share on Facebook</TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <a
-                href={shareLinks.twitter}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Share on Twitter"
-                className="inline-flex items-center justify-center rounded-full h-12 w-12 bg-[#1DA1F2] text-white hover:bg-[#1DA1F2]/80 transition-colors"
-              >
-                <Twitter className="h-5 w-5" />
-              </a>
-            }
-          />
-          <TooltipContent>Share on Twitter</TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <a
-                href={shareLinks.linkedin}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Share on LinkedIn"
-                className="inline-flex items-center justify-center rounded-full h-12 w-12 bg-[#0A66C2] text-white hover:bg-[#0A66C2]/80 transition-colors"
-              >
-                <Linkedin className="h-5 w-5" />
-              </a>
-            }
-          />
-          <TooltipContent>Share on LinkedIn</TooltipContent>
-        </Tooltip>
+    <div className={cn("flex flex-col gap-3", className)}>
+      <h3 className="text-eyebrow">Share this article</h3>
+      <div className="flex gap-2.5">
+        {shareLinks.map(({ label, href, Icon }) => (
+          <Tooltip key={label}>
+            <TooltipTrigger
+              render={
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={label}
+                  className={shareButtonClasses}
+                >
+                  <Icon className="h-4 w-4" />
+                </a>
+              }
+            />
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        ))}
 
         <Tooltip>
           <TooltipTrigger
@@ -114,19 +80,17 @@ export function ShareArticle({
               <button
                 onClick={handleCopyLink}
                 aria-label="Copy link to clipboard"
-                className="inline-flex items-center justify-center rounded-full h-12 w-12 border border-border bg-card text-foreground hover:bg-muted transition-colors"
+                className={shareButtonClasses}
               >
                 {copied ? (
-                  <Check className="h-5 w-5 text-green-500" />
+                  <Check className="h-4 w-4 text-emerald-500" />
                 ) : (
-                  <Link2 className="h-5 w-5" />
+                  <Link2 className="h-4 w-4" />
                 )}
               </button>
             }
           />
-          <TooltipContent>
-            {copied ? "Copied!" : "Copy link"}
-          </TooltipContent>
+          <TooltipContent>{copied ? "Copied!" : "Copy link"}</TooltipContent>
         </Tooltip>
       </div>
     </div>

--- a/src/features/blog/components/ShareArticle.tsx
+++ b/src/features/blog/components/ShareArticle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   Tooltip,
   TooltipContent,
@@ -8,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Facebook, Twitter, Linkedin, Link2, Check } from "lucide-react";
 import { toast } from "sonner";
+import { DURATION } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 interface ShareArticleProps {
@@ -17,7 +19,7 @@ interface ShareArticleProps {
 }
 
 const shareButtonClasses =
-  "inline-flex h-10 w-10 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors duration-200 hover:border-primary hover:bg-primary/10 hover:text-primary";
+  "inline-flex h-10 w-10 items-center justify-center rounded-full border border-border text-muted-foreground transition-all duration-200 hover:border-primary hover:bg-primary/10 hover:text-primary motion-safe:active:scale-90";
 
 export function ShareArticle({ title, url, className }: ShareArticleProps) {
   const [copied, setCopied] = useState(false);
@@ -82,11 +84,22 @@ export function ShareArticle({ title, url, className }: ShareArticleProps) {
                 aria-label="Copy link to clipboard"
                 className={shareButtonClasses}
               >
-                {copied ? (
-                  <Check className="h-4 w-4 text-emerald-500" />
-                ) : (
-                  <Link2 className="h-4 w-4" />
-                )}
+                <AnimatePresence mode="wait" initial={false}>
+                  <motion.span
+                    key={copied ? "copied" : "copy"}
+                    initial={{ scale: 0.5, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={{ scale: 0.5, opacity: 0 }}
+                    transition={{ duration: DURATION.fast }}
+                    className="inline-flex"
+                  >
+                    {copied ? (
+                      <Check className="h-4 w-4 text-emerald-500" />
+                    ) : (
+                      <Link2 className="h-4 w-4" />
+                    )}
+                  </motion.span>
+                </AnimatePresence>
               </button>
             }
           />

--- a/src/features/blog/components/ShareArticle.tsx
+++ b/src/features/blog/components/ShareArticle.tsx
@@ -19,7 +19,7 @@ interface ShareArticleProps {
 }
 
 const shareButtonClasses =
-  "inline-flex h-10 w-10 items-center justify-center rounded-full border border-border text-muted-foreground transition-all duration-200 hover:border-primary hover:bg-primary/10 hover:text-primary motion-safe:active:scale-90";
+  "pressable inline-flex h-10 w-10 items-center justify-center rounded-full border border-border text-muted-foreground transition-all duration-200 hover:border-primary hover:bg-primary/10 hover:text-primary";
 
 export function ShareArticle({ title, url, className }: ShareArticleProps) {
   const [copied, setCopied] = useState(false);

--- a/src/features/blog/components/TableOfContents.tsx
+++ b/src/features/blog/components/TableOfContents.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface TocItem {
   id: string;
@@ -172,86 +173,86 @@ export function TableOfContents({ className = "" }: TableOfContentsProps) {
 
   if (!hasCompletedInitialScan) {
     return (
-      <Card className={`sticky top-24 ${className}`}>
-        <CardHeader className="pb-2">
-          <h3 className="font-bold flex items-center">
-            <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-            Table of Contents
-          </h3>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Loading table of contents...
-          </p>
-        </CardContent>
-      </Card>
+      <TocShell className={className}>
+        <p className="text-sm text-muted-foreground">
+          Loading table of contents...
+        </p>
+      </TocShell>
     );
   }
 
   if (tocItems.length === 0) {
     return (
-      <Card className={`sticky top-24 ${className}`}>
-        <CardHeader className="pb-2">
-          <h3 className="font-bold flex items-center">
-            <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-            Table of Contents
-          </h3>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">No sections available.</p>
-        </CardContent>
-      </Card>
+      <TocShell className={className}>
+        <p className="text-sm text-muted-foreground">No sections available.</p>
+      </TocShell>
     );
   }
 
   return (
-    <Card className={`sticky top-24 ${className}`}>
+    <TocShell
+      className={className}
+      action={
+        <Button
+          variant="ghost"
+          size="icon"
+          className="lg:hidden"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          aria-label="Toggle table of contents"
+        >
+          {isCollapsed ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronUp className="h-4 w-4" />
+          )}
+        </Button>
+      }
+    >
+      <ScrollArea className={isCollapsed ? "hidden lg:block" : "block"}>
+        <nav
+          aria-label="Table of contents"
+          className="space-y-0.5 text-[13px] max-h-[60vh]"
+        >
+          {tocItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => handleTocClick(item.id)}
+              className={cn(
+                "block w-full border-l-2 py-1.5 text-left leading-snug transition-colors duration-200",
+                item.level === 2 ? "pl-3.5" : "pl-6 text-xs",
+                activeId === item.id
+                  ? "border-primary font-medium text-primary"
+                  : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
+              )}
+            >
+              {item.text}
+            </button>
+          ))}
+        </nav>
+      </ScrollArea>
+    </TocShell>
+  );
+}
+
+/** Shared card frame for every TOC state (loading, empty, populated). */
+function TocShell({
+  className,
+  action,
+  children,
+}: {
+  className?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className={cn("sticky top-24", className)}>
       <CardHeader className="pb-2">
-        <div className="flex justify-between items-center">
-          <h3 className="font-bold flex items-center">
-            <span className="inline-block w-1 h-8 bg-primary rounded-sm mr-2" />
-            Table of Contents
-          </h3>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="lg:hidden"
-            onClick={() => setIsCollapsed(!isCollapsed)}
-            aria-label="Toggle table of contents"
-          >
-            {isCollapsed ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronUp className="h-4 w-4" />
-            )}
-          </Button>
+        <div className="flex items-center justify-between">
+          <h3 className="text-eyebrow">On this page</h3>
+          {action}
         </div>
       </CardHeader>
-      <CardContent>
-        <ScrollArea
-          className={`${isCollapsed ? "hidden lg:block" : "block"}`}
-        >
-          <nav className="space-y-1 text-sm max-h-[60vh]">
-            {tocItems.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => handleTocClick(item.id)}
-                className={`
-                  block w-full text-left py-2 border-l-2 transition-all duration-200
-                  ${item.level === 2 ? "pl-4" : "pl-6 text-xs"}
-                  ${
-                    activeId === item.id
-                      ? "text-primary border-primary bg-primary/10"
-                      : "text-muted-foreground border-border hover:text-primary hover:border-primary"
-                  }
-                `}
-              >
-                {item.text}
-              </button>
-            ))}
-          </nav>
-        </ScrollArea>
-      </CardContent>
+      <CardContent>{children}</CardContent>
     </Card>
   );
 }

--- a/src/features/blog/components/TableOfContents.tsx
+++ b/src/features/blog/components/TableOfContents.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SPRING_SNAPPY } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 interface TocItem {
@@ -55,6 +57,11 @@ export function TableOfContents({ className = "" }: TableOfContentsProps) {
   const [hasCompletedInitialScan, setHasCompletedInitialScan] = useState(false);
   const mutationObserverRef = useRef<MutationObserver | null>(null);
   const headingObserverRef = useRef<IntersectionObserver | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const instanceId = useId();
+  const railLayoutId = prefersReducedMotion
+    ? undefined
+    : `${instanceId}-toc-rail`;
 
   useEffect(() => {
     const articleContent = document.querySelector("[data-article-content]");
@@ -218,13 +225,21 @@ export function TableOfContents({ className = "" }: TableOfContentsProps) {
               key={item.id}
               onClick={() => handleTocClick(item.id)}
               className={cn(
-                "block w-full border-l-2 py-1.5 text-left leading-snug transition-colors duration-200",
+                "relative block w-full border-l-2 border-border py-1.5 text-left leading-snug transition-colors duration-200",
                 item.level === 2 ? "pl-3.5" : "pl-6 text-xs",
                 activeId === item.id
-                  ? "border-primary font-medium text-primary"
-                  : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                  ? "font-medium text-primary"
+                  : "text-muted-foreground hover:text-foreground"
               )}
             >
+              {activeId === item.id && (
+                <motion.span
+                  aria-hidden
+                  layoutId={railLayoutId}
+                  transition={SPRING_SNAPPY}
+                  className="absolute -left-0.5 inset-y-0 w-0.5 bg-primary"
+                />
+              )}
               {item.text}
             </button>
           ))}

--- a/src/features/blog/index.ts
+++ b/src/features/blog/index.ts
@@ -3,6 +3,7 @@ export { BlogDetailPage } from "./BlogDetailPage";
 export { useBlogListingStore } from "./store";
 export { useBlogDetailStore } from "./detailStore";
 export { BlogCard } from "./components/BlogCard";
+export { BlogGrid, BlogGridSkeleton } from "./components/BlogGrid";
 export { BlogSearch } from "./components/BlogSearch";
 export { BlogSidebar } from "./components/BlogSidebar";
 export { CategoryTabs } from "./components/CategoryTabs";

--- a/src/features/blog/store.ts
+++ b/src/features/blog/store.ts
@@ -29,6 +29,7 @@ interface BlogListingState {
   // Pagination
   currentPage: number;
   hasMorePosts: boolean;
+  totalCount: number;
 
   // Loading states
   blogsLoading: boolean;
@@ -92,6 +93,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     sortBy: "newest",
     currentPage: 1,
     hasMorePosts: false,
+    totalCount: 0,
     blogsLoading: true,
     categoriesLoading: true,
     categoryLoading: false,
@@ -103,7 +105,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     // ─── Hydration from Server ───
 
     hydrateFromServer: (data) => {
-      const { blogs, categories, hasMore, currentPage } = data;
+      const { blogs, categories, hasMore, currentPage, totalCount } = data;
 
       const blogTags = blogs.flatMap((blog: BlogPost) => blog.tags || []);
       const uniqueTags = Array.from(new Set(blogTags.filter(Boolean)));
@@ -130,6 +132,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
         allTags: uniqueTags,
         currentPage,
         hasMorePosts: hasMore,
+        totalCount,
         blogsLoading: false,
         categoriesLoading: false,
         activeCategory: resolvedCategory,
@@ -197,12 +200,14 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
             blogs: data.blogs,
             currentPage: data.currentPage || 1,
             hasMorePosts: data.hasMore || false,
+            totalCount: data.totalCount ?? data.blogs.length,
             allTags: uniqueTags,
             error: null,
           });
         } else {
           set({
             blogs: [],
+            totalCount: 0,
             error: "No articles available.",
           });
         }
@@ -252,6 +257,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
           blogs: allBlogs,
           currentPage: response.currentPage,
           hasMorePosts: response.hasMore,
+          totalCount: response.totalCount ?? allBlogs.length,
           allTags: mergedTags,
         });
       } catch (error) {

--- a/src/features/blog/store.ts
+++ b/src/features/blog/store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import type { BlogPost, BlogCategory } from "@/types/blog";
+import { getUniqueTags } from "@/lib/blogUtils";
 import {
   getAllBlogCategories,
   getBlogsPaginated,
@@ -107,8 +108,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     hydrateFromServer: (data) => {
       const { blogs, categories, hasMore, currentPage, totalCount } = data;
 
-      const blogTags = blogs.flatMap((blog: BlogPost) => blog.tags || []);
-      const uniqueTags = Array.from(new Set(blogTags.filter(Boolean)));
+      const uniqueTags = getUniqueTags(blogs);
 
       // Check if there's a pending unresolved category name from URL params
       // (hydrateFromParams may have run before categories were loaded)
@@ -192,16 +192,12 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
         }
 
         if (data?.blogs) {
-          // Extract tags
-          const blogTags = data.blogs.flatMap((blog: BlogPost) => blog.tags || []);
-          const uniqueTags = Array.from(new Set(blogTags.filter(Boolean)));
-
           set({
             blogs: data.blogs,
             currentPage: data.currentPage || 1,
             hasMorePosts: data.hasMore || false,
             totalCount: data.totalCount ?? data.blogs.length,
-            allTags: uniqueTags,
+            allTags: getUniqueTags(data.blogs),
             error: null,
           });
         } else {
@@ -249,16 +245,13 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
         }
 
         const allBlogs = [...blogs, ...response.blogs];
-        const mergedTags = Array.from(
-          new Set(allBlogs.flatMap((blog) => blog.tags || []).filter(Boolean))
-        );
 
         set({
           blogs: allBlogs,
           currentPage: response.currentPage,
           hasMorePosts: response.hasMore,
           totalCount: response.totalCount ?? allBlogs.length,
-          allTags: mergedTags,
+          allTags: getUniqueTags(allBlogs),
         });
       } catch (error) {
         console.error("Failed to load more blogs:", error);

--- a/src/hooks/use-blog-url-params/index.ts
+++ b/src/hooks/use-blog-url-params/index.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useBlogListingStore } from "@/features/blog";
 
 /**
@@ -14,7 +14,6 @@ import { useBlogListingStore } from "@/features/blog";
  * URL — drop-in replacements for the raw store actions.
  */
 export function useBlogUrlParams() {
-  const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
 
@@ -28,20 +27,31 @@ export function useBlogUrlParams() {
     hydrateFromParams,
   } = useBlogListingStore();
 
-  // ── Hydrate store from URL params on mount ──────────────────────────────
+  // ── Hydrate store from URL params ────────────────────────────────────────
+  // Reads location.search in an effect (never during render) so the listing
+  // page stays fully prerenderable — a render-time useSearchParams() would
+  // force the whole tree to client-render behind the route Suspense fallback.
+  // popstate keeps back/forward navigation in sync.
   useEffect(() => {
-    const tagParam = searchParams.get("tag");
-    const categoryParam = searchParams.get("category");
-    const searchParam = searchParams.get("search");
+    const syncFromLocation = () => {
+      const params = new URLSearchParams(window.location.search);
+      const tagParam = params.get("tag");
+      const categoryParam = params.get("category");
+      const searchParam = params.get("search");
 
-    if (tagParam || categoryParam || searchParam) {
-      hydrateFromParams({
-        tag: tagParam,
-        category: categoryParam,
-        search: searchParam,
-      });
-    }
-  }, [searchParams, hydrateFromParams]);
+      if (tagParam || categoryParam || searchParam) {
+        hydrateFromParams({
+          tag: tagParam,
+          category: categoryParam,
+          search: searchParam,
+        });
+      }
+    };
+
+    syncFromLocation();
+    window.addEventListener("popstate", syncFromLocation);
+    return () => window.removeEventListener("popstate", syncFromLocation);
+  }, [hydrateFromParams]);
 
   // ── Helper: push current filter state into the URL ──────────────────────
   const updateUrlParams = useCallback(

--- a/src/lib/blogUtils.ts
+++ b/src/lib/blogUtils.ts
@@ -1,6 +1,10 @@
 // Blog-specific utilities — ported from my-brand-nextjs/utils/blogUtils.ts
 
-import { DEFAULT_AUTHOR } from "./constants";
+import {
+  BLOG_PLACEHOLDER_IMAGE,
+  DEFAULT_AUTHOR,
+  DEFAULT_READ_TIME,
+} from "./constants";
 import type { Author, BlogPost } from "@/types/blog";
 import { format, formatDistanceToNow, parseISO } from "date-fns";
 
@@ -67,6 +71,29 @@ export function getSafeImageSrc(
   }
 
   return fallback;
+}
+
+/**
+ * Cover image src for a post, falling back to the shared blog placeholder.
+ */
+export function getPostImageSrc(post: Pick<BlogPost, "imageUrl">): string {
+  return getSafeImageSrc(post.imageUrl, BLOG_PLACEHOLDER_IMAGE);
+}
+
+/**
+ * Read time for a post, falling back to the shared default.
+ */
+export function getReadTime(post: Pick<BlogPost, "readTime">): string {
+  return post.readTime || DEFAULT_READ_TIME;
+}
+
+/**
+ * Unique, non-empty tags across a set of posts (insertion order preserved).
+ */
+export function getUniqueTags(posts: Pick<BlogPost, "tags">[]): string[] {
+  return Array.from(
+    new Set(posts.flatMap((post) => post.tags || []).filter(Boolean))
+  );
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,6 +18,10 @@ export const SOCIAL_LINKS = {
   email: "hello@ndevuspace.com",
 } as const;
 
+// Blog post display fallbacks
+export const BLOG_PLACEHOLDER_IMAGE = "/images/blog/placeholder.jpg";
+export const DEFAULT_READ_TIME = "5 min read";
+
 // Default author info
 export const DEFAULT_AUTHOR = {
   name: "Jean Paul Elisa NIYOKWIZERWA",

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,80 @@
+// Motion design tokens — the single source of timing, easing, and variant
+// truth for the public pages. Components compose these; they never define
+// their own durations or curves inline.
+
+import type { Transition, Variants } from "framer-motion";
+
+// ─── Easing & duration scale ───
+
+/** Standard deceleration curve for entrances. */
+export const EASE_OUT = [0.22, 0.61, 0.36, 1] as const;
+
+export const DURATION = {
+  /** Micro-interactions: icon swaps, taps. */
+  fast: 0.15,
+  /** Element entrances: cards, headings. */
+  base: 0.35,
+  /** Page-level moments: hero reveal, scroll reveals. */
+  slow: 0.45,
+} as const;
+
+// ─── Springs ───
+
+/** Sliding indicators (active pill, TOC rail) — quick, minimal overshoot. */
+export const SPRING_SNAPPY: Transition = {
+  type: "spring",
+  stiffness: 420,
+  damping: 34,
+};
+
+/** Layout reflow (grid re-sorting) — calm, no wobble. */
+export const SPRING_GENTLE: Transition = {
+  type: "spring",
+  stiffness: 260,
+  damping: 32,
+};
+
+// ─── Shared variants ───
+
+/** Standard entrance: fade in while rising into place. */
+export const fadeRise: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: DURATION.base, ease: EASE_OUT },
+  },
+};
+
+/** Media entrance: fade with a slight settle from scale. */
+export const fadeScale: Variants = {
+  hidden: { opacity: 0, scale: 0.985 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: DURATION.slow, ease: EASE_OUT },
+  },
+};
+
+/** Parent that staggers `fadeRise`/`fadeScale` children. */
+export function staggerContainer(stagger = 0.08, delay = 0): Variants {
+  return {
+    hidden: {},
+    visible: {
+      transition: { staggerChildren: stagger, delayChildren: delay },
+    },
+  };
+}
+
+/**
+ * Props for a one-off entrance on a motion element. Returns an empty object
+ * when the user prefers reduced motion, so the element renders statically.
+ */
+export function entrance(reducedMotion: boolean | null, delay = 0) {
+  if (reducedMotion) return {};
+  return {
+    initial: { opacity: 0, y: 12 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: DURATION.base, ease: EASE_OUT, delay },
+  } as const;
+}


### PR DESCRIPTION
Foundation (globals.css):
- Body copy restored to full foreground contrast; muted reserved for metadata
- Modest semantic heading defaults (hero scale is now opt-in per usage)
- Theme-aware ::selection (was unreadable white-on-pale-blue in light mode)
- prefers-reduced-motion respected for scroll behavior
- New shared type roles: .text-eyebrow / .text-meta (JetBrains Mono voice)
- .glass refined to surface-only; new .glass-scrim for over-image strips
- Removed all unused utilities, keyframes, and tokens (text-gradient, glow, bg-grid/dots, section-fade, scrollbar-hide, fade/slide/scale/float/modal)

Components:
- BlogCard: flat resting state with hairline ring, aspect-video cover, glass meta strip (category + read time), pulsing New dot, stretched-link whole-card target, line-clamp-3 excerpt, mono meta footer with arrow affordance, 200-350ms motion-safe hovers; new "featured" variant
- New BlogGrid owns columns/spans + staggered entrance (framer-motion, reduced-motion aware); BlogCardSkeleton mirrors the new anatomy
- New SectionHeading replaces the colored-bar heading pattern everywhere
- New ReadingProgress scroll bar on article pages
- BlogSearch: glass pill field with inline icon + round submit; dead debounce ref removed; state sync moved out of effect (lint clean)
- CategoryTabs: glass filter strip, active pill glow, cn()-based classes
- BlogPage: deduplicated loading branches, "Showing X of Y" count (store now tracks totalCount), featured first post on unfiltered view, sticky sidebar, proper empty-results state
- BlogDetailPage: article un-carded onto the open page, category eyebrow, like moved into a share/actions cluster, redundant Home breadcrumb dropped, related cards match the new card language, dead commented comments block removed
- TableOfContents: three duplicated card shells collapsed into TocShell, "On this page" instrument styling with active rail
- ShareArticle: single presentation (inline mode removed), neutral round buttons that tint brand on hover
