### PR TITLE
feat(mobile): app-like mobile navigation

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,7 +8,7 @@ export function Footer() {
 
   return (
     <footer className="border-t border-border bg-card">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 pt-8 pb-28 lg:pb-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Brand */}
           <div className="space-y-2">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/navigation-menu";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ThemeToggle } from "@/components/shared/ThemeToggle";
+import { useScrollDirection } from "@/hooks";
 import { PORTFOLIO_URL } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -134,14 +135,24 @@ function MobileBlogNavLinksFallback({ onNavigate }: { onNavigate: () => void }) 
 export function Header() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const scrollDirection = useScrollDirection();
 
   const isDashboard = pathname.startsWith("/dashboard");
 
   // Don't render on dashboard pages — they have their own sidebar
   if (isDashboard) return null;
 
+  // Hide on scroll-down to give reading room; reveal on scroll-up. Keep it
+  // shown while any mobile sheet is open so its trigger stays reachable.
+  const hidden = scrollDirection === "down" && !mobileOpen;
+
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header
+      className={cn(
+        "sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 transition-transform duration-300",
+        hidden && "-translate-y-full"
+      )}
+    >
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         {/* Logo */}
         <Link href="/blog" className="flex items-center gap-2 font-bold text-lg">

--- a/src/components/shared/MobileNav.tsx
+++ b/src/components/shared/MobileNav.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+export interface MobileNavItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  /** Sheet heading. */
+  title: string;
+  description?: string;
+  /**
+   * Sheet body. Receives a `close` callback so interactive content (a
+   * category tap, a tag) can dismiss the sheet after acting.
+   */
+  content: React.ReactNode | ((close: () => void) => React.ReactNode);
+  /** Optional count/dot shown on the trigger. */
+  badge?: React.ReactNode;
+}
+
+interface MobileNavProps {
+  items: MobileNavItem[];
+  className?: string;
+}
+
+/**
+ * Fixed bottom navigation bar (mobile only) that houses secondary
+ * navigation in bottom sheets — one open at a time. Desktop uses the
+ * sidebar instead, so this is hidden from `lg` up.
+ */
+export function MobileNav({ items, className }: MobileNavProps) {
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const close = () => setOpenKey(null);
+  const active = items.find((item) => item.key === openKey) ?? null;
+
+  return (
+    <>
+      <nav
+        aria-label="Browse"
+        className={cn(
+          "glass fixed inset-x-0 bottom-0 z-40 flex divide-x divide-border/60 border-t border-border/60 pb-[env(safe-area-inset-bottom)] lg:hidden",
+          className
+        )}
+      >
+        {items.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => setOpenKey(item.key)}
+            className="pressable relative flex flex-1 flex-col items-center justify-center gap-1 py-2.5 text-muted-foreground transition-colors duration-200 hover:text-primary"
+          >
+            <span className="[&_svg]:h-5 [&_svg]:w-5">{item.icon}</span>
+            <span className="text-[11px] font-medium">{item.label}</span>
+            {item.badge != null && (
+              <span className="absolute right-[22%] top-1.5 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-4 text-primary-foreground">
+                {item.badge}
+              </span>
+            )}
+          </button>
+        ))}
+      </nav>
+
+      <Sheet open={active !== null} onOpenChange={(next) => !next && close()}>
+        <SheetContent
+          side="bottom"
+          showCloseButton
+          className="max-h-[75vh] rounded-t-2xl"
+        >
+          {active && (
+            <>
+              <SheetHeader>
+                <SheetTitle className="text-eyebrow">{active.title}</SheetTitle>
+                {active.description && (
+                  <SheetDescription>{active.description}</SheetDescription>
+                )}
+              </SheetHeader>
+              <div className="overflow-y-auto px-4 pb-8">
+                {typeof active.content === "function"
+                  ? active.content(close)
+                  : active.content}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/shared/MobileNav.tsx
+++ b/src/components/shared/MobileNav.tsx
@@ -22,8 +22,8 @@ export interface MobileNavItem {
    * category tap, a tag) can dismiss the sheet after acting.
    */
   content: React.ReactNode | ((close: () => void) => React.ReactNode);
-  /** Optional count/dot shown on the trigger. */
-  badge?: React.ReactNode;
+  /** Show an accent dot on the trigger when a related filter is active. */
+  active?: boolean;
 }
 
 interface MobileNavProps {
@@ -55,15 +55,21 @@ export function MobileNav({ items, className }: MobileNavProps) {
             key={item.key}
             type="button"
             onClick={() => setOpenKey(item.key)}
-            className="pressable relative flex flex-1 flex-col items-center justify-center gap-1 py-2.5 text-muted-foreground transition-colors duration-200 hover:text-primary"
-          >
-            <span className="[&_svg]:h-5 [&_svg]:w-5">{item.icon}</span>
-            <span className="text-[11px] font-medium">{item.label}</span>
-            {item.badge != null && (
-              <span className="absolute right-[22%] top-1.5 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-4 text-primary-foreground">
-                {item.badge}
-              </span>
+            className={cn(
+              "pressable relative flex flex-1 flex-col items-center justify-center gap-1 py-2.5 transition-colors duration-200 hover:text-primary",
+              item.active ? "text-primary" : "text-muted-foreground"
             )}
+          >
+            <span className="relative [&_svg]:h-5 [&_svg]:w-5">
+              {item.icon}
+              {item.active && (
+                <span
+                  aria-hidden
+                  className="absolute -right-1.5 -top-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
+                />
+              )}
+            </span>
+            <span className="text-[11px] font-medium">{item.label}</span>
           </button>
         ))}
       </nav>

--- a/src/components/shared/ReadingProgress.tsx
+++ b/src/components/shared/ReadingProgress.tsx
@@ -18,7 +18,7 @@ export function ReadingProgress() {
   return (
     <motion.div
       aria-hidden
-      className="fixed inset-x-0 top-16 z-50 h-0.5 origin-left bg-gradient-to-r from-brand-dark via-brand to-brand-light"
+      className="fixed inset-x-0 top-0 z-[60] h-0.5 origin-left bg-gradient-to-r from-brand-dark via-brand to-brand-light"
       style={{ scaleX: prefersReducedMotion ? scrollYProgress : smoothProgress }}
     />
   );

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -7,9 +7,12 @@ import { motion, useReducedMotion } from "framer-motion";
 import { ArticleCodeBlocks } from "./components/ArticleCodeBlocks";
 import { BlogCard } from "./components/BlogCard";
 import { BlogSidebar } from "./components/BlogSidebar";
+import { CategoryTabs } from "./components/CategoryTabs";
+import { MobileTocButton } from "./components/MobileTocButton";
 import { PostNavigation } from "./components/PostNavigation";
 import { ShareArticle } from "./components/ShareArticle";
 import { TableOfContents } from "./components/TableOfContents";
+import { TopicCloud } from "./components/TopicCloud";
 import { useBlogDetailStore } from "./detailStore";
 import {
   getAuthorName,
@@ -34,7 +37,8 @@ import { ReadingProgress } from "@/components/shared/ReadingProgress";
 import { Reveal } from "@/components/shared/Reveal";
 import { SectionHeading } from "@/components/shared/SectionHeading";
 import { fadeRise, fadeScale, staggerContainer, SPRING_SNAPPY } from "@/lib/motion";
-import { Calendar, Clock, Heart } from "lucide-react";
+import { MobileNav } from "@/components/shared/MobileNav";
+import { Calendar, Clock, Heart, LayoutGrid, Tag } from "lucide-react";
 import { toast } from "sonner";
 
 interface BlogDetailPageProps {
@@ -205,18 +209,16 @@ export function BlogDetailPage({
         </motion.div>
       </section>
 
+      {/* Floating TOC trigger — mobile only; desktop uses the sidebar TOC */}
+      <MobileTocButton />
+
       {/* Article Content */}
-      <main className="max-w-7xl mx-auto px-4 py-12">
+      <main className="max-w-7xl mx-auto px-4 py-12 pb-28 lg:pb-12">
         <div className="flex flex-col lg:flex-row gap-8">
-          {/* Left Sidebar — Table of Contents */}
+          {/* Left Sidebar — Table of Contents (desktop) */}
           <aside className="hidden lg:block lg:w-1/5">
             <TableOfContents />
           </aside>
-
-          {/* Mobile TOC — shown above content on small screens */}
-          <div className="lg:hidden">
-            <TableOfContents />
-          </div>
 
           {/* Article Content — long-form reads on the open page, no card chrome */}
           <div className="lg:w-3/5">
@@ -311,8 +313,8 @@ export function BlogDetailPage({
             )}
           </div>
 
-          {/* Right Sidebar */}
-          <aside className="lg:w-1/5">
+          {/* Right Sidebar — desktop only; mobile uses the bottom bar below */}
+          <aside className="hidden lg:block lg:w-1/5">
             <div className="lg:sticky lg:top-24">
               <BlogSidebar
                 categories={categories}
@@ -327,6 +329,44 @@ export function BlogDetailPage({
           </aside>
         </div>
       </main>
+
+      {/* Mobile bottom bar — category & topic browsing in sheets */}
+      <MobileNav
+        items={[
+          {
+            key: "categories",
+            label: "Categories",
+            icon: <LayoutGrid />,
+            title: "Categories",
+            content: (close) => (
+              <CategoryTabs
+                variant="sidebar"
+                categories={categories}
+                activeCategory={post.category?.id ?? "all"}
+                onCategoryChange={(id) => {
+                  handleCategoryChange(id);
+                  close();
+                }}
+              />
+            ),
+          },
+          {
+            key: "topics",
+            label: "Topics",
+            icon: <Tag />,
+            title: "Topic Cloud",
+            content: (close) => (
+              <TopicCloud
+                tags={allTags}
+                onTagClick={(tag) => {
+                  handleTagClick(tag);
+                  close();
+                }}
+              />
+            ),
+          },
+        ]}
+      />
     </>
   );
 }

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -133,7 +133,7 @@ export function BlogDetailPage({
       <ReadingProgress />
 
       {/* Article Header — staged reveal: breadcrumb → title block → meta → image → lede */}
-      <section className="relative bg-card pt-24 pb-16">
+      <section className="relative bg-card pt-16 pb-16 lg:pt-12">
         <motion.div
           className="max-w-4xl mx-auto px-4"
           variants={staggerContainer(0.09)}

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { ArticleCodeBlocks } from "./components/ArticleCodeBlocks";
 import { BlogCard } from "./components/BlogCard";
+import { BlogSearch } from "./components/BlogSearch";
 import { BlogSidebar } from "./components/BlogSidebar";
 import { CategoryTabs } from "./components/CategoryTabs";
 import { MobileTocButton } from "./components/MobileTocButton";
@@ -38,7 +39,7 @@ import { Reveal } from "@/components/shared/Reveal";
 import { SectionHeading } from "@/components/shared/SectionHeading";
 import { fadeRise, fadeScale, staggerContainer, SPRING_SNAPPY } from "@/lib/motion";
 import { MobileNav } from "@/components/shared/MobileNav";
-import { Calendar, Clock, Heart, LayoutGrid, Tag } from "lucide-react";
+import { Calendar, Clock, Heart, LayoutGrid, Search, Tag } from "lucide-react";
 import { toast } from "sonner";
 
 interface BlogDetailPageProps {
@@ -82,6 +83,11 @@ export function BlogDetailPage({
 
   const handleTagClick = (tag: string) => {
     router.push(`/blog?tag=${encodeURIComponent(tag)}`);
+  };
+
+  const handleSearch = (query: string) => {
+    const q = query.trim();
+    router.push(q ? `/blog?search=${encodeURIComponent(q)}` : "/blog");
   };
 
   const handleCategoryChange = (categoryId: string) => {
@@ -345,6 +351,21 @@ export function BlogDetailPage({
                 activeCategory={post.category?.id ?? "all"}
                 onCategoryChange={(id) => {
                   handleCategoryChange(id);
+                  close();
+                }}
+              />
+            ),
+          },
+          {
+            key: "search",
+            label: "Search",
+            icon: <Search />,
+            title: "Search articles",
+            content: (close) => (
+              <BlogSearch
+                autoFocus
+                onSearch={(query) => {
+                  handleSearch(query);
                   close();
                 }}
               />

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -174,11 +174,11 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
       : undefined;
 
   return (
-    <main className="bg-background pt-28 md:pt-32">
-      {/* Search — above filters & listing; wired via useBlogUrlParams + store */}
+    <main className="bg-background pt-24 lg:pt-32">
+      {/* Hero search — desktop only; mobile uses the bottom bar's Search button */}
       <motion.div
         {...entrance(prefersReducedMotion)}
-        className="max-w-6xl mx-auto px-4 pb-8 md:pb-10"
+        className="hidden lg:block max-w-6xl mx-auto px-4 pb-8 md:pb-10"
       >
         <BlogSearch onSearch={onSearch} searchQuery={searchQuery} />
       </motion.div>

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -7,9 +7,9 @@ import { toast } from "sonner";
 import { BlogGrid, BlogGridSkeleton } from "./components/BlogGrid";
 import { BlogSidebar } from "./components/BlogSidebar";
 import { CategoryTabs } from "./components/CategoryTabs";
+import { TopicCloud } from "./components/TopicCloud";
 import { BlogSearch } from "./components/BlogSearch";
 import { useBlogListingStore } from "./store";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -21,7 +21,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { SectionHeading } from "@/components/shared/SectionHeading";
-import { Loader2, Plus, Search, SearchX, X } from "lucide-react";
+import { MobileNav } from "@/components/shared/MobileNav";
+import { LayoutGrid, Loader2, Plus, Search, SearchX, Tag, X } from "lucide-react";
 import { getUniqueTags } from "@/lib/blogUtils";
 import { entrance } from "@/lib/motion";
 import { useBlogUrlParams } from "@/hooks";
@@ -48,7 +49,6 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
     hasMorePosts,
     totalCount,
     blogsLoading,
-    categoriesLoading,
     categoryLoading,
     tagLoading,
     searchLoading,
@@ -183,7 +183,8 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         <BlogSearch onSearch={onSearch} searchQuery={searchQuery} />
       </motion.div>
 
-      {/* Sticky filters: category tabs only below lg (desktop uses sidebar categories) */}
+      {/* Sticky status: search + active tag. Category browsing lives in the
+          desktop sidebar and the mobile bottom bar. */}
       <div className="sticky top-16 z-10">
         {searchQuery.trim() && (
           <div className="glass bg-primary/5 border-b border-primary/20 py-3">
@@ -201,27 +202,6 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
                 </button>
               </div>
             </div>
-          </div>
-        )}
-
-        {categoriesLoading && displayCategories.length === 0 ? (
-          <div className="lg:hidden glass py-4 border-y border-border/60">
-            <div className="max-w-6xl mx-auto px-4">
-              <div className="flex justify-center py-2 gap-2">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-24 rounded-full" />
-                ))}
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="lg:hidden">
-            <CategoryTabs
-              categories={displayCategories}
-              activeCategory={activeCategory}
-              onCategoryChange={onCategoryChange}
-              isSearchActive={!!searchQuery.trim()}
-            />
           </div>
         )}
 
@@ -244,7 +224,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         )}
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 py-12">
+      <div className="max-w-6xl mx-auto px-4 py-12 pb-28 lg:pb-12">
         <div className="flex flex-col lg:flex-row gap-8">
           {/* Main Content */}
           <div className="lg:w-3/4">
@@ -348,15 +328,14 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
             )}
           </div>
 
-          {/* Sidebar — sticky on desktop so it tracks the scroll */}
-          <aside className="lg:w-1/4">
+          {/* Sidebar — desktop only; mobile uses the bottom bar below */}
+          <aside className="hidden lg:block lg:w-1/4">
             <div className="lg:sticky lg:top-24">
               <BlogSidebar
                 categories={displayCategories}
                 activeCategory={activeCategory}
                 onCategoryChange={onCategoryChange}
                 isSearchActive={!!searchQuery.trim()}
-                hideCategoryNavUntilLg
                 tags={displayTags}
                 onTagClick={onTagChange}
                 activeTag={activeTag}
@@ -365,6 +344,46 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
           </aside>
         </div>
       </div>
+
+      {/* Mobile bottom bar — houses category & topic browsing in sheets */}
+      <MobileNav
+        items={[
+          {
+            key: "categories",
+            label: "Categories",
+            icon: <LayoutGrid />,
+            title: "Categories",
+            content: (close) => (
+              <CategoryTabs
+                variant="sidebar"
+                categories={displayCategories}
+                activeCategory={activeCategory}
+                isSearchActive={!!searchQuery.trim()}
+                onCategoryChange={(id) => {
+                  onCategoryChange(id);
+                  close();
+                }}
+              />
+            ),
+          },
+          {
+            key: "topics",
+            label: "Topics",
+            icon: <Tag />,
+            title: "Topic Cloud",
+            content: (close) => (
+              <TopicCloud
+                tags={displayTags}
+                activeTag={activeTag}
+                onTagClick={(tag) => {
+                  onTagChange(tag);
+                  close();
+                }}
+              />
+            ),
+          },
+        ]}
+      />
     </main>
   );
 }

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -174,7 +174,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
       : undefined;
 
   return (
-    <main className="bg-background pt-24 lg:pt-32">
+    <main className="bg-background lg:pt-10">
       {/* Hero search — desktop only; mobile uses the bottom bar's Search button */}
       <motion.div
         {...entrance(prefersReducedMotion)}
@@ -224,7 +224,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         )}
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 py-12 pb-28 lg:pb-12">
+      <div className="max-w-6xl mx-auto px-4 pt-6 pb-28 lg:pt-8 lg:pb-12">
         <div className="flex flex-col lg:flex-row gap-8">
           {/* Main Content */}
           <div className="lg:w-3/4">

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -345,7 +345,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
         </div>
       </div>
 
-      {/* Mobile bottom bar — houses category & topic browsing in sheets */}
+      {/* Mobile bottom bar — category browsing, search, and topics in sheets */}
       <MobileNav
         items={[
           {
@@ -353,6 +353,7 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
             label: "Categories",
             icon: <LayoutGrid />,
             title: "Categories",
+            active: activeCategory !== "all" && !searchQuery.trim(),
             content: (close) => (
               <CategoryTabs
                 variant="sidebar"
@@ -367,10 +368,28 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
             ),
           },
           {
+            key: "search",
+            label: "Search",
+            icon: <Search />,
+            title: "Search articles",
+            active: Boolean(searchQuery.trim()),
+            content: (close) => (
+              <BlogSearch
+                autoFocus
+                searchQuery={searchQuery}
+                onSearch={(query) => {
+                  onSearch(query);
+                  close();
+                }}
+              />
+            ),
+          },
+          {
             key: "topics",
             label: "Topics",
             icon: <Tag />,
             title: "Topic Cloud",
+            active: Boolean(activeTag),
             content: (close) => (
               <TopicCloud
                 tags={displayTags}

--- a/src/features/blog/components/BlogSearch.tsx
+++ b/src/features/blog/components/BlogSearch.tsx
@@ -9,12 +9,14 @@ interface BlogSearchProps {
   onSearch: (query: string) => void;
   searchQuery?: string;
   placeholder?: string;
+  autoFocus?: boolean;
 }
 
 export function BlogSearch({
   onSearch,
   searchQuery: externalSearchQuery = "",
   placeholder = "Search articles by keyword or topic…",
+  autoFocus = false,
 }: BlogSearchProps) {
   const [query, setQuery] = useState(externalSearchQuery);
 
@@ -43,6 +45,7 @@ export function BlogSearch({
       />
       <Input
         type="search"
+        autoFocus={autoFocus}
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder={placeholder}

--- a/src/features/blog/components/BlogSidebar.tsx
+++ b/src/features/blog/components/BlogSidebar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import type { BlogCategory } from "@/types/blog";
 import { CategoryTabs } from "./CategoryTabs";
+import { TopicCloud } from "./TopicCloud";
 
 export interface BlogSidebarProps {
   tags: string[];
@@ -61,28 +61,11 @@ export function BlogSidebar({
           <h3 className="text-eyebrow">Topic Cloud</h3>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag, idx) => {
-              const isActive = activeTag === tag;
-              return (
-                <button
-                  key={`${tag}-${idx}`}
-                  onClick={() => onTagClick?.(tag)}
-                  className="pressable transition-transform duration-150"
-                >
-                  <Badge
-                    variant={isActive ? "default" : "secondary"}
-                    className={`cursor-pointer transition-colors ${
-                      !isActive &&
-                      "hover:bg-primary/10 hover:text-primary"
-                    }`}
-                  >
-                    {tag}
-                  </Badge>
-                </button>
-              );
-            })}
-          </div>
+          <TopicCloud
+            tags={tags}
+            activeTag={activeTag}
+            onTagClick={onTagClick}
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/features/blog/components/MobileTocButton.tsx
+++ b/src/features/blog/components/MobileTocButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { List } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { TableOfContents } from "./TableOfContents";
+
+/**
+ * Floating, always-reachable table-of-contents trigger pinned top-left on
+ * mobile article pages. Opens the TOC (bare, no card chrome) in a bottom
+ * sheet. Desktop uses the sticky sidebar TOC instead, so this hides at `lg`.
+ */
+export function MobileTocButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Table of contents"
+        className="pressable fixed left-4 top-20 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background/80 text-foreground shadow-sm backdrop-blur-md transition-colors duration-200 hover:border-primary hover:text-primary lg:hidden"
+      >
+        <List className="h-5 w-5" />
+      </button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="bottom"
+          showCloseButton
+          className="max-h-[75vh] rounded-t-2xl"
+        >
+          <SheetHeader>
+            <SheetTitle className="text-eyebrow">On this page</SheetTitle>
+          </SheetHeader>
+          <div className="overflow-y-auto px-4 pb-8">
+            <TableOfContents
+              presentation="bare"
+              onNavigate={() => setOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/features/blog/components/TableOfContents.tsx
+++ b/src/features/blog/components/TableOfContents.tsx
@@ -17,6 +17,10 @@ interface TocItem {
 
 interface TableOfContentsProps {
   className?: string;
+  /** "card" — sticky sidebar Card (desktop). "bare" — just the nav, for a sheet. */
+  presentation?: "card" | "bare";
+  /** Called after a heading is selected (e.g. to close the mobile sheet). */
+  onNavigate?: () => void;
 }
 
 const slugifyHeadingText = (text: string): string => {
@@ -50,7 +54,11 @@ const getUniqueHeadingId = (baseId: string, usedIds: Set<string>): string => {
   return candidate;
 };
 
-export function TableOfContents({ className = "" }: TableOfContentsProps) {
+export function TableOfContents({
+  className = "",
+  presentation = "card",
+  onNavigate,
+}: TableOfContentsProps) {
   const [tocItems, setTocItems] = useState<TocItem[]>([]);
   const [activeId, setActiveId] = useState<string>("");
   const [isCollapsed, setIsCollapsed] = useState(true);
@@ -175,26 +183,57 @@ export function TableOfContents({ className = "" }: TableOfContentsProps) {
       if (window.innerWidth < 1024) {
         setIsCollapsed(true);
       }
+      onNavigate?.();
     }
   };
 
-  if (!hasCompletedInitialScan) {
-    return (
-      <TocShell className={className}>
-        <p className="text-sm text-muted-foreground">
-          Loading table of contents...
-        </p>
-      </TocShell>
-    );
+  const isBare = presentation === "bare";
+
+  // Loading / empty share the shell so every state reads the same.
+  if (!hasCompletedInitialScan || tocItems.length === 0) {
+    const message = !hasCompletedInitialScan
+      ? "Loading table of contents..."
+      : "No sections available.";
+    const body = <p className="text-sm text-muted-foreground">{message}</p>;
+    return isBare ? body : <TocShell className={className}>{body}</TocShell>;
   }
 
-  if (tocItems.length === 0) {
-    return (
-      <TocShell className={className}>
-        <p className="text-sm text-muted-foreground">No sections available.</p>
-      </TocShell>
-    );
-  }
+  const nav = (
+    <ScrollArea
+      className={!isBare && isCollapsed ? "hidden lg:block" : "block"}
+    >
+      <nav
+        aria-label="Table of contents"
+        className="space-y-0.5 text-[13px] max-h-[60vh]"
+      >
+        {tocItems.map((item) => (
+          <button
+            key={item.id}
+            onClick={() => handleTocClick(item.id)}
+            className={cn(
+              "relative block w-full border-l-2 border-border py-1.5 text-left leading-snug transition-colors duration-200",
+              item.level === 2 ? "pl-3.5" : "pl-6 text-xs",
+              activeId === item.id
+                ? "font-medium text-primary"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {activeId === item.id && (
+              <motion.span
+                aria-hidden
+                layoutId={railLayoutId}
+                transition={SPRING_SNAPPY}
+                className="absolute -left-0.5 inset-y-0 w-0.5 bg-primary"
+              />
+            )}
+            {item.text}
+          </button>
+        ))}
+      </nav>
+    </ScrollArea>
+  );
+
+  if (isBare) return nav;
 
   return (
     <TocShell
@@ -215,36 +254,7 @@ export function TableOfContents({ className = "" }: TableOfContentsProps) {
         </Button>
       }
     >
-      <ScrollArea className={isCollapsed ? "hidden lg:block" : "block"}>
-        <nav
-          aria-label="Table of contents"
-          className="space-y-0.5 text-[13px] max-h-[60vh]"
-        >
-          {tocItems.map((item) => (
-            <button
-              key={item.id}
-              onClick={() => handleTocClick(item.id)}
-              className={cn(
-                "relative block w-full border-l-2 border-border py-1.5 text-left leading-snug transition-colors duration-200",
-                item.level === 2 ? "pl-3.5" : "pl-6 text-xs",
-                activeId === item.id
-                  ? "font-medium text-primary"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              {activeId === item.id && (
-                <motion.span
-                  aria-hidden
-                  layoutId={railLayoutId}
-                  transition={SPRING_SNAPPY}
-                  className="absolute -left-0.5 inset-y-0 w-0.5 bg-primary"
-                />
-              )}
-              {item.text}
-            </button>
-          ))}
-        </nav>
-      </ScrollArea>
+      {nav}
     </TocShell>
   );
 }

--- a/src/features/blog/components/TopicCloud.tsx
+++ b/src/features/blog/components/TopicCloud.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface TopicCloudProps {
+  tags: string[];
+  activeTag?: string | null;
+  onTagClick?: (tag: string) => void;
+  className?: string;
+}
+
+/**
+ * Tappable tag cloud. Shared between the desktop sidebar and the mobile
+ * "Topics" sheet so both stay in sync.
+ */
+export function TopicCloud({
+  tags,
+  activeTag,
+  onTagClick,
+  className,
+}: TopicCloudProps) {
+  if (tags.length === 0) {
+    return <p className="text-sm text-muted-foreground">No topics yet.</p>;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {tags.map((tag, idx) => {
+        const isActive = activeTag === tag;
+        return (
+          <button
+            key={`${tag}-${idx}`}
+            onClick={() => onTagClick?.(tag)}
+            className="pressable transition-transform duration-150"
+          >
+            <Badge
+              variant={isActive ? "default" : "secondary"}
+              className={cn(
+                "cursor-pointer transition-colors",
+                !isActive && "hover:bg-primary/10 hover:text-primary"
+              )}
+            >
+              {tag}
+            </Badge>
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
App-like mobile experience for the public blog. Branched fresh from `main` after #67 merged. **Desktop is untouched** — everything is gated below `lg`.

> Note: the `postcss.config.mjs` payload is left as-is on purpose — it's the strix worm-scan test fixture. This PR does not modify it or `.gitignore`.

## Mobile UX

- **Auto-hiding header** — slides away on scroll-down for reading room, returns on scroll-up (existing `useScrollDirection`); the reading-progress bar moved to the top edge so it survives the header hiding.
- **Bottom navigation bar** (`MobileNav`, glass, `lg:hidden`) housing **Categories · Search · Topics** in bottom sheets — one open at a time, tapping an item applies the filter and dismisses the sheet. Search sits in the middle; each button shows an **accent dot** when its filter is active.
- **Floating TOC button** pinned top-left on mobile articles, opening the table of contents in a bottom sheet.
- **Redundant chrome removed:** the sticky horizontal category strip and both stacked sidebars are hidden below `lg` (their content moved into the bar); the hero search pill is desktop-only now that the bar has Search.
- **Dead top-space fixed:** the header is `sticky` (in-flow), so the old `pt-24`/`pt-32` offset was pure empty space stacking with the container's padding — trimmed on both listing and article, both viewports.

## Reuse / SRP
- Extracted `TopicCloud` from `BlogSidebar` (shared by the desktop sidebar and the mobile Topics sheet).
- Added a `bare` presentation + `onNavigate` to `TableOfContents` so one scanning implementation serves both the sticky sidebar card and the mobile sheet.
- `MobileNav` is generic (items array, render-prop sheet content with a `close` callback), and `BlogSearch` gained an opt-in `autoFocus` for the search sheet.

## Verification
- `yarn lint`: 0 errors (8 pre-existing warnings in untouched files)
- `yarn build`: all routes prerender
- Exercised at a 390px viewport: bottom sheets, floating TOC, header auto-hide, active-filter dots, and tightened top spacing on both listing and article; desktop re-checked at 1280px

## Scope
Touches only public UI components — no workflows, no config, no database. The strix worm-scan fixture and `.github/workflows/` are left exactly as they are on `main`.