### PR TITLE
feat(blog): server-sourced weighted topic cloud with infinite scroll

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -39,7 +39,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     getBlogBySlug(slug),
     getAllBlogCategories(),
     getAdjacentBlogs(slug).catch(() => ({ newer: null, older: null })),
-    getPublicTags(1, TOPIC_PAGE_SIZE),
+    // Topics are secondary — never let a tag-fetch failure (e.g. the RPC not
+    // yet applied) break the page. The client store loads them on mount.
+    getPublicTags(1, TOPIC_PAGE_SIZE).catch(() => undefined),
   ]);
 
   if (!post) {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,8 +4,10 @@ import {
   getAdjacentBlogs,
   getAllBlogCategories,
   getBlogBySlug,
+  getPublicTags,
 } from "@/features/blog/services/resolvedBlogService";
 import { BlogDetailPage } from "@/features/blog";
+import { TOPIC_PAGE_SIZE } from "@/features/blog/topicCloudStore";
 import { highlightCodeBlocks } from "@/lib/highlightCode";
 import {
   buildBlogPostJsonLd,
@@ -33,10 +35,11 @@ export async function generateMetadata({
 
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { slug } = await params;
-  const [post, categories, adjacent] = await Promise.all([
+  const [post, categories, adjacent, initialTags] = await Promise.all([
     getBlogBySlug(slug),
     getAllBlogCategories(),
     getAdjacentBlogs(slug).catch(() => ({ newer: null, older: null })),
+    getPublicTags(1, TOPIC_PAGE_SIZE),
   ]);
 
   if (!post) {
@@ -60,6 +63,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         post={highlightedPost}
         categories={categories}
         adjacent={adjacent}
+        initialTags={initialTags}
       />
     </>
   );

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -15,7 +15,9 @@ export default async function BlogListingPage() {
   const [initialBlogs, initialCategories, initialTags] = await Promise.all([
     getBlogsPaginated(1, 10),
     getAllBlogCategories(),
-    getPublicTags(1, TOPIC_PAGE_SIZE),
+    // Topics are secondary — never let a tag-fetch failure (e.g. the RPC not
+    // yet applied) break the page. The client store loads them on mount.
+    getPublicTags(1, TOPIC_PAGE_SIZE).catch(() => undefined),
   ]);
 
   return (

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,21 +4,25 @@ import { homeMetadata } from "../../lib/seo/metadata";
 import {
   getBlogsPaginated,
   getAllBlogCategories,
+  getPublicTags,
 } from "@/features/blog/services/resolvedBlogService";
+import { TOPIC_PAGE_SIZE } from "@/features/blog/topicCloudStore";
 
 export const metadata: Metadata = homeMetadata;
 
 export default async function BlogListingPage() {
   // Fetch initial data server-side (where process.env[key] works correctly)
-  const [initialBlogs, initialCategories] = await Promise.all([
+  const [initialBlogs, initialCategories, initialTags] = await Promise.all([
     getBlogsPaginated(1, 10),
     getAllBlogCategories(),
+    getPublicTags(1, TOPIC_PAGE_SIZE),
   ]);
 
   return (
     <BlogPage
       initialBlogs={initialBlogs}
       initialCategories={initialCategories}
+      initialTags={initialTags}
     />
   );
 }

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { AdjacentBlogs, BlogCategory, BlogPost } from "@/types/blog";
+import type {
+  AdjacentBlogs,
+  BlogCategory,
+  BlogPost,
+  PaginatedTagsResponse,
+} from "@/types/blog";
 import Image from "next/image";
 import { useEffect } from "react";
 import { motion, useReducedMotion } from "framer-motion";
@@ -15,6 +20,7 @@ import { ShareArticle } from "./components/ShareArticle";
 import { TableOfContents } from "./components/TableOfContents";
 import { TopicCloud } from "./components/TopicCloud";
 import { useBlogDetailStore } from "./detailStore";
+import { useHydrateTopicCloud } from "./topicCloudStore";
 import {
   getAuthorName,
   getAuthorImage,
@@ -46,25 +52,28 @@ interface BlogDetailPageProps {
   post: BlogPost;
   categories: BlogCategory[];
   adjacent?: AdjacentBlogs;
+  initialTags: PaginatedTagsResponse;
 }
 
 export function BlogDetailPage({
   post,
   categories,
   adjacent,
+  initialTags,
 }: BlogDetailPageProps) {
   const router = useRouter();
   const prefersReducedMotion = useReducedMotion();
 
+  useHydrateTopicCloud(initialTags);
+
   // ─── Store ───
   const {
-    allTags,
     relatedPosts,
     liked,
     likeCount,
     currentUrl,
     initializePost,
-    fetchSidebarData,
+    fetchRelatedPosts,
     toggleLike,
     trackView,
     reset,
@@ -73,13 +82,13 @@ export function BlogDetailPage({
   // Initialize on mount / post change
   useEffect(() => {
     initializePost(post);
-    fetchSidebarData(post);
+    fetchRelatedPosts(post);
     trackView(post.id);
 
     return () => {
       reset();
     };
-  }, [post, initializePost, fetchSidebarData, trackView, reset]);
+  }, [post, initializePost, fetchRelatedPosts, trackView, reset]);
 
   const handleTagClick = (tag: string) => {
     router.push(`/blog?tag=${encodeURIComponent(tag)}`);
@@ -327,7 +336,6 @@ export function BlogDetailPage({
                 activeCategory={post.category?.id ?? "all"}
                 onCategoryChange={handleCategoryChange}
                 isSearchActive={false}
-                tags={allTags}
                 onTagClick={handleTagClick}
                 activeTag={null}
               />
@@ -378,7 +386,6 @@ export function BlogDetailPage({
             title: "Topic Cloud",
             content: (close) => (
               <TopicCloud
-                tags={allTags}
                 onTagClick={(tag) => {
                   handleTagClick(tag);
                   close();

--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -52,7 +52,8 @@ interface BlogDetailPageProps {
   post: BlogPost;
   categories: BlogCategory[];
   adjacent?: AdjacentBlogs;
-  initialTags: PaginatedTagsResponse;
+  /** Omitted when the server tag fetch fails; the client store then loads it. */
+  initialTags?: PaginatedTagsResponse;
 }
 
 export function BlogDetailPage({

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -35,7 +35,8 @@ import type {
 export interface BlogPageProps {
   initialBlogs: PaginatedBlogsResponse;
   initialCategories: BlogCategory[];
-  initialTags: PaginatedTagsResponse;
+  /** Omitted when the server tag fetch fails; the client store then loads it. */
+  initialTags?: PaginatedTagsResponse;
 }
 
 export function BlogPage({

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -10,6 +10,7 @@ import { CategoryTabs } from "./components/CategoryTabs";
 import { TopicCloud } from "./components/TopicCloud";
 import { BlogSearch } from "./components/BlogSearch";
 import { useBlogListingStore } from "./store";
+import { useHydrateTopicCloud } from "./topicCloudStore";
 import {
   Select,
   SelectContent,
@@ -23,25 +24,34 @@ import { InfiniteScrollSentinel } from "@/components/shared/InfiniteScrollSentin
 import { SectionHeading } from "@/components/shared/SectionHeading";
 import { MobileNav } from "@/components/shared/MobileNav";
 import { LayoutGrid, Search, SearchX, Tag, X } from "lucide-react";
-import { getUniqueTags } from "@/lib/blogUtils";
 import { entrance } from "@/lib/motion";
 import { useBlogUrlParams } from "@/hooks";
-import type { BlogCategory, PaginatedBlogsResponse } from "@/types/blog";
+import type {
+  BlogCategory,
+  PaginatedBlogsResponse,
+  PaginatedTagsResponse,
+} from "@/types/blog";
 
 export interface BlogPageProps {
   initialBlogs: PaginatedBlogsResponse;
   initialCategories: BlogCategory[];
+  initialTags: PaginatedTagsResponse;
 }
 
-export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
+export function BlogPage({
+  initialBlogs,
+  initialCategories,
+  initialTags,
+}: BlogPageProps) {
   const router = useRouter();
   const pathname = usePathname();
+
+  useHydrateTopicCloud(initialTags);
 
   // ─── Store ───
   const {
     blogs,
     blogCategories,
-    allTags,
     activeCategory,
     activeTag,
     searchQuery,
@@ -123,10 +133,6 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
   const displayHasMore = useServerData ? initialBlogs.hasMore : hasMorePosts;
   const displayCategories =
     blogCategories.length > 0 ? blogCategories : initialCategories;
-  const displayTags = useMemo(
-    () => (allTags.length > 0 ? allTags : getUniqueTags(initialBlogs.blogs)),
-    [allTags, initialBlogs.blogs]
-  );
 
   const isContentLoading =
     (blogsLoading && !useServerData) ||
@@ -321,7 +327,6 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
                 activeCategory={activeCategory}
                 onCategoryChange={onCategoryChange}
                 isSearchActive={!!searchQuery.trim()}
-                tags={displayTags}
                 onTagClick={onTagChange}
                 activeTag={activeTag}
               />
@@ -377,7 +382,6 @@ export function BlogPage({ initialBlogs, initialCategories }: BlogPageProps) {
             active: Boolean(activeTag),
             content: (close) => (
               <TopicCloud
-                tags={displayTags}
                 activeTag={activeTag}
                 onTagClick={(tag) => {
                   onTagChange(tag);

--- a/src/features/blog/components/BlogSidebar.tsx
+++ b/src/features/blog/components/BlogSidebar.tsx
@@ -6,7 +6,6 @@ import { CategoryTabs } from "./CategoryTabs";
 import { TopicCloud } from "./TopicCloud";
 
 export interface BlogSidebarProps {
-  tags: string[];
   onTagClick?: (tag: string) => void;
   activeTag?: string | null;
   categories?: BlogCategory[];
@@ -18,7 +17,6 @@ export interface BlogSidebarProps {
 }
 
 export function BlogSidebar({
-  tags,
   onTagClick,
   activeTag,
   categories,
@@ -61,11 +59,7 @@ export function BlogSidebar({
           <h3 className="text-eyebrow">Topic Cloud</h3>
         </CardHeader>
         <CardContent>
-          <TopicCloud
-            tags={tags}
-            activeTag={activeTag}
-            onTagClick={onTagClick}
-          />
+          <TopicCloud activeTag={activeTag} onTagClick={onTagClick} />
         </CardContent>
       </Card>
     </div>

--- a/src/features/blog/components/TopicBadge.tsx
+++ b/src/features/blog/components/TopicBadge.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface TopicBadgeProps {
+  name: string;
+  postCount: number;
+  /** Highest count in the set; used to size this topic relative to the rest. */
+  maxPostCount: number;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+/**
+ * Weight buckets, largest first. `min` is the postCount/maxPostCount ratio
+ * threshold, so sizing is relative and stable regardless of the absolute
+ * count range (dummy 1–4 or production 1–50 both spread across the buckets).
+ */
+const WEIGHTS = [
+  { min: 0.75, className: "text-base font-bold px-3.5 py-1.5" },
+  { min: 0.5, className: "text-sm font-semibold px-3 py-1.5" },
+  { min: 0.25, className: "text-sm font-medium px-3 py-1" },
+  { min: 0, className: "text-xs font-medium px-2.5 py-1 opacity-90" },
+] as const;
+
+function weightClass(postCount: number, maxPostCount: number): string {
+  const ratio = maxPostCount > 0 ? postCount / maxPostCount : 0;
+  return (WEIGHTS.find((w) => ratio >= w.min) ?? WEIGHTS[WEIGHTS.length - 1])
+    .className;
+}
+
+/** A single topic chip, sized by how many posts carry it. */
+export function TopicBadge({
+  name,
+  postCount,
+  maxPostCount,
+  active = false,
+  onClick,
+}: TopicBadgeProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={`${postCount} ${postCount === 1 ? "article" : "articles"}`}
+      className={cn(
+        "pressable rounded-full border transition-colors duration-150",
+        weightClass(postCount, maxPostCount),
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border bg-secondary text-secondary-foreground hover:border-primary/50 hover:text-primary"
+      )}
+    >
+      {name}
+    </button>
+  );
+}

--- a/src/features/blog/components/TopicCloud.tsx
+++ b/src/features/blog/components/TopicCloud.tsx
@@ -1,51 +1,87 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { useEffect, useRef } from "react";
+import { Loader2 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useInfiniteScroll } from "@/hooks";
+import { useTopicCloudStore } from "../topicCloudStore";
+import { TopicBadge } from "./TopicBadge";
 
 interface TopicCloudProps {
-  tags: string[];
   activeTag?: string | null;
   onTagClick?: (tag: string) => void;
-  className?: string;
 }
 
 /**
- * Tappable tag cloud. Shared between the desktop sidebar and the mobile
- * "Topics" sheet so both stay in sync.
+ * Server-sourced, weighted topic cloud. Reads the shared topic store (so the
+ * listing and article pages share one fetch) and infinite-scrolls the capped
+ * set in alphabetical batches inside its own bounded panel.
  */
-export function TopicCloud({
-  tags,
-  activeTag,
-  onTagClick,
-  className,
-}: TopicCloudProps) {
-  if (tags.length === 0) {
-    return <p className="text-sm text-muted-foreground">No topics yet.</p>;
-  }
+export function TopicCloud({ activeTag, onTagClick }: TopicCloudProps) {
+  const { topics, maxPostCount, hasMore, loading, initialized, error } =
+    useTopicCloudStore();
+  const ensureLoaded = useTopicCloudStore((s) => s.ensureLoaded);
+  const loadMore = useTopicCloudStore((s) => s.loadMore);
 
+  // Load page 1 if the page didn't already hydrate the store (idempotent).
+  useEffect(() => {
+    ensureLoaded();
+  }, [ensureLoaded]);
+
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useInfiniteScroll({
+    onLoadMore: loadMore,
+    hasMore,
+    loading,
+    rootRef: panelRef,
+    // Small prefetch so batches stream in as the panel scrolls, rather than
+    // all at once — the cloud is short, so a large margin would load everything.
+    rootMargin: "48px",
+    // Re-evaluate against the new layout after each batch appends.
+    resetKey: topics.length,
+  });
+
+  const showSkeleton = !initialized && loading;
+  const showEmpty = initialized && topics.length === 0;
+
+  // Panel + sentinel always render so the infinite-scroll observer stays
+  // attached across the pre-hydration → loaded transition.
   return (
-    <div className={cn("flex flex-wrap gap-2", className)}>
-      {tags.map((tag, idx) => {
-        const isActive = activeTag === tag;
-        return (
-          <button
-            key={`${tag}-${idx}`}
-            onClick={() => onTagClick?.(tag)}
-            className="pressable transition-transform duration-150"
-          >
-            <Badge
-              variant={isActive ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer transition-colors",
-                !isActive && "hover:bg-primary/10 hover:text-primary"
-              )}
-            >
-              {tag}
-            </Badge>
-          </button>
-        );
-      })}
+    <div ref={panelRef} className="max-h-56 overflow-y-auto pr-1">
+      {showSkeleton ? (
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-7 w-20 rounded-full" />
+          ))}
+        </div>
+      ) : showEmpty ? (
+        <p className="text-sm text-muted-foreground">
+          {error ?? "No topics yet."}
+        </p>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          {topics.map((topic) => (
+            <TopicBadge
+              key={topic.id}
+              name={topic.name}
+              postCount={topic.postCount}
+              maxPostCount={maxPostCount}
+              active={activeTag === topic.name}
+              onClick={() => onTagClick?.(topic.name)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Sentinel — auto-loads the next alphabetical batch within this panel. */}
+      <div ref={sentinelRef} className="flex h-8 items-center justify-center">
+        {loading && initialized && (
+          <Loader2
+            className="h-4 w-4 animate-spin text-muted-foreground"
+            aria-hidden
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/blog/detailStore.ts
+++ b/src/features/blog/detailStore.ts
@@ -2,10 +2,8 @@
 
 import { create } from "zustand";
 import type { BlogPost, BlogComment } from "@/types/blog";
-import { getUniqueTags } from "@/lib/blogUtils";
 import {
   getBlogsByCategory,
-  getBlogsPaginated,
   incrementBlogView,
   likeBlog,
 } from "./services/resolvedBlogService";
@@ -14,7 +12,6 @@ import {
 
 interface BlogDetailState {
   // Sidebar data
-  allTags: string[];
   relatedPosts: BlogPost[];
 
   // Comments
@@ -34,7 +31,7 @@ interface BlogDetailState {
 interface BlogDetailActions {
   // Initialization
   initializePost: (post: BlogPost) => void;
-  fetchSidebarData: (post: BlogPost) => Promise<void>;
+  fetchRelatedPosts: (post: BlogPost) => Promise<void>;
 
   // Like
   toggleLike: (postId: string) => Promise<void>;
@@ -50,7 +47,6 @@ interface BlogDetailActions {
 }
 
 const initialState: BlogDetailState = {
-  allTags: [],
   relatedPosts: [],
   comments: [],
   liked: false,
@@ -80,13 +76,10 @@ export const useBlogDetailStore = create<BlogDetailState & BlogDetailActions>(
       });
     },
 
-    fetchSidebarData: async (post) => {
+    fetchRelatedPosts: async (post) => {
       set({ sidebarLoading: true });
 
       try {
-        const allBlogsData = await getBlogsPaginated(1, 20);
-        const uniqueTags = getUniqueTags(allBlogsData.blogs ?? []);
-
         let relatedPosts: BlogPost[] = [];
         if (post.category?.id) {
           const categoryPosts = await getBlogsByCategory(post.category.id, 1, 6);
@@ -95,18 +88,10 @@ export const useBlogDetailStore = create<BlogDetailState & BlogDetailActions>(
             .slice(0, 3);
         }
 
-        set({
-          allTags: uniqueTags,
-          relatedPosts,
-          sidebarLoading: false,
-        });
+        set({ relatedPosts, sidebarLoading: false });
       } catch (error) {
-        console.error("Error fetching blog detail data:", error);
-        set({
-          allTags: [],
-          relatedPosts: [],
-          sidebarLoading: false,
-        });
+        console.error("Error fetching related posts:", error);
+        set({ relatedPosts: [], sidebarLoading: false });
       }
     },
 

--- a/src/features/blog/services/blogService.ts
+++ b/src/features/blog/services/blogService.ts
@@ -3,7 +3,9 @@ import type {
   AdjacentBlogs,
   BlogCategory,
   BlogPost,
+  BlogTag,
   PaginatedBlogsResponse,
+  PaginatedTagsResponse,
 } from "@/types/blog";
 
 type RpcObject = Record<string, unknown>;
@@ -203,6 +205,36 @@ export async function incrementBlogView(blogId: string): Promise<number | null> 
 
   const payload = assertRpcObject(data, "Invalid view increment response.");
   return typeof payload.views_count === "number" ? payload.views_count : null;
+}
+
+function parsePaginatedTags(data: unknown): PaginatedTagsResponse {
+  const payload = assertRpcObject(data, "Invalid tags response.");
+  return {
+    tags: Array.isArray(payload.tags) ? (payload.tags as BlogTag[]) : [],
+    totalCount: typeof payload.totalCount === "number" ? payload.totalCount : 0,
+    maxPostCount:
+      typeof payload.maxPostCount === "number" ? payload.maxPostCount : 0,
+    hasMore: Boolean(payload.hasMore),
+    currentPage:
+      typeof payload.currentPage === "number" ? payload.currentPage : 1,
+  };
+}
+
+export async function getPublicTags(
+  page: number = 1,
+  limit: number = 10
+): Promise<PaginatedTagsResponse> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("blog_public_tags_list", {
+    p_page: page,
+    p_limit: limit,
+  });
+
+  if (error) {
+    throw new Error(error.message || "Failed to fetch tags.");
+  }
+
+  return parsePaginatedTags(data);
 }
 
 export async function getAllBlogCategories(): Promise<BlogCategory[]> {

--- a/src/features/blog/services/dummyBlogService.ts
+++ b/src/features/blog/services/dummyBlogService.ts
@@ -5,9 +5,48 @@ import type {
   AdjacentBlogs,
   BlogCategory,
   BlogPost,
+  BlogTag,
   PaginatedBlogsResponse,
+  PaginatedTagsResponse,
 } from "@/types/blog";
 import { dummyBlogs, dummyCategories } from "@/data/dummyBlogs";
+
+const TAG_CLOUD_CAP = 30;
+
+function slugifyTag(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Mirror of blog_public_tags_list against the in-memory posts: count
+ * published posts per tag, keep the top {@link TAG_CLOUD_CAP} by popularity,
+ * then serve that capped set in alphabetical pages.
+ */
+function rankPublishedTags(): BlogTag[] {
+  const counts = new Map<string, number>();
+  for (const blog of dummyBlogs) {
+    for (const tag of blog.tags || []) {
+      if (tag) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([name, postCount]) => ({ name, postCount }))
+    // Popularity first, then name — to select the capped set.
+    .sort((a, b) => b.postCount - a.postCount || a.name.localeCompare(b.name))
+    .slice(0, TAG_CLOUD_CAP)
+    // Display alphabetically so paginated batches stay A–Z.
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(({ name, postCount }) => ({
+      id: slugifyTag(name),
+      name,
+      slug: slugifyTag(name),
+      postCount,
+    }));
+}
 
 function paginate(
   posts: BlogPost[],
@@ -109,6 +148,22 @@ export async function getAdjacentBlogs(slug: string): Promise<AdjacentBlogs> {
 export async function incrementBlogView(blogId: string): Promise<number | null> {
   const post = dummyBlogs.find((b) => b.id === blogId);
   return post ? (post.viewsCount ?? 0) + 1 : null;
+}
+
+export async function getPublicTags(
+  page: number = 1,
+  limit: number = 10
+): Promise<PaginatedTagsResponse> {
+  const all = rankPublishedTags();
+  const start = (page - 1) * limit;
+  const tags = all.slice(start, start + limit);
+  return {
+    tags,
+    totalCount: all.length,
+    maxPostCount: all.reduce((max, tag) => Math.max(max, tag.postCount), 0),
+    hasMore: start + limit < all.length,
+    currentPage: page,
+  };
 }
 
 export async function getAllBlogCategories(): Promise<BlogCategory[]> {

--- a/src/features/blog/services/resolvedBlogService.ts
+++ b/src/features/blog/services/resolvedBlogService.ts
@@ -14,6 +14,7 @@ type BlogApiContract = {
   likeBlog: typeof blogApi.likeBlog;
   getAdjacentBlogs: typeof blogApi.getAdjacentBlogs;
   incrementBlogView: typeof blogApi.incrementBlogView;
+  getPublicTags: typeof blogApi.getPublicTags;
   getAllBlogCategories: typeof blogApi.getAllBlogCategories;
 };
 
@@ -30,5 +31,6 @@ export const searchBlogsByTitle = resolved.searchBlogsByTitle;
 export const likeBlog = resolved.likeBlog;
 export const getAdjacentBlogs = resolved.getAdjacentBlogs;
 export const incrementBlogView = resolved.incrementBlogView;
+export const getPublicTags = resolved.getPublicTags;
 export const getAllBlogCategories = resolved.getAllBlogCategories;
 

--- a/src/features/blog/store.ts
+++ b/src/features/blog/store.ts
@@ -2,7 +2,6 @@
 
 import { create } from "zustand";
 import type { BlogPost, BlogCategory } from "@/types/blog";
-import { getUniqueTags } from "@/lib/blogUtils";
 import {
   getAllBlogCategories,
   getBlogsPaginated,
@@ -19,7 +18,6 @@ interface BlogListingState {
   // Data
   blogs: BlogPost[];
   blogCategories: BlogCategory[];
-  allTags: string[];
 
   // Filters
   activeCategory: string;
@@ -87,7 +85,6 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     // Initial state
     blogs: [],
     blogCategories: [],
-    allTags: [],
     activeCategory: "all",
     activeTag: null,
     searchQuery: "",
@@ -108,8 +105,6 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     hydrateFromServer: (data) => {
       const { blogs, categories, hasMore, currentPage, totalCount } = data;
 
-      const uniqueTags = getUniqueTags(blogs);
-
       // Check if there's a pending unresolved category name from URL params
       // (hydrateFromParams may have run before categories were loaded)
       const { activeCategory } = get();
@@ -129,7 +124,6 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
       set({
         blogs,
         blogCategories: categories,
-        allTags: uniqueTags,
         currentPage,
         hasMorePosts: hasMore,
         totalCount,
@@ -197,7 +191,6 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
             currentPage: data.currentPage || 1,
             hasMorePosts: data.hasMore || false,
             totalCount: data.totalCount ?? data.blogs.length,
-            allTags: getUniqueTags(data.blogs),
             error: null,
           });
         } else {
@@ -251,7 +244,6 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
           currentPage: response.currentPage,
           hasMorePosts: response.hasMore,
           totalCount: response.totalCount ?? allBlogs.length,
-          allTags: getUniqueTags(allBlogs),
         });
       } catch (error) {
         console.error("Failed to load more blogs:", error);

--- a/src/features/blog/topicCloudStore.ts
+++ b/src/features/blog/topicCloudStore.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect } from "react";
+import { create } from "zustand";
+import type { BlogTag, PaginatedTagsResponse } from "@/types/blog";
+import { getPublicTags } from "./services/resolvedBlogService";
+
+/** Topics per infinite-scroll batch. */
+export const TOPIC_PAGE_SIZE = 10;
+
+interface TopicCloudState {
+  topics: BlogTag[];
+  currentPage: number;
+  hasMore: boolean;
+  /** Highest postCount in the capped set; constant across pages, for weighting. */
+  maxPostCount: number;
+  loading: boolean;
+  /** True once page 1 has been provided (server hydrate or client fetch). */
+  initialized: boolean;
+  error: string | null;
+}
+
+interface TopicCloudActions {
+  /** Seed page 1 from server-rendered props. Idempotent — no-ops once initialized. */
+  hydrate: (firstPage: PaginatedTagsResponse) => void;
+  /** Fetch page 1 on the client if the store was never seeded. Idempotent. */
+  ensureLoaded: () => Promise<void>;
+  /** Append the next batch. Guarded against concurrent / past-the-end calls. */
+  loadMore: () => Promise<void>;
+}
+
+/** Append new tags, de-duplicating by id (defensive against overlapping pages). */
+function mergeTags(existing: BlogTag[], incoming: BlogTag[]): BlogTag[] {
+  if (incoming.length === 0) return existing;
+  const seen = new Set(existing.map((tag) => tag.id));
+  return existing.concat(incoming.filter((tag) => !seen.has(tag.id)));
+}
+
+const initialState: TopicCloudState = {
+  topics: [],
+  currentPage: 0,
+  hasMore: false,
+  maxPostCount: 0,
+  loading: false,
+  initialized: false,
+  error: null,
+};
+
+/**
+ * Global topic-cloud store, shared by the listing and article pages so the
+ * canonical topics are fetched once and reused across navigation. Topics are
+ * server-ranked (popularity-capped, A–Z) and paginated for infinite scroll.
+ */
+export const useTopicCloudStore = create<TopicCloudState & TopicCloudActions>(
+  (set, get) => ({
+    ...initialState,
+
+    hydrate: (firstPage) => {
+      if (get().initialized) return;
+      set({
+        topics: firstPage.tags,
+        currentPage: firstPage.currentPage,
+        hasMore: firstPage.hasMore,
+        maxPostCount: firstPage.maxPostCount,
+        initialized: true,
+        error: null,
+      });
+    },
+
+    ensureLoaded: async () => {
+      const { initialized, loading } = get();
+      if (initialized || loading) return;
+
+      set({ loading: true });
+      try {
+        const data = await getPublicTags(1, TOPIC_PAGE_SIZE);
+        set({
+          topics: data.tags,
+          currentPage: data.currentPage,
+          hasMore: data.hasMore,
+          maxPostCount: data.maxPostCount,
+          initialized: true,
+          error: null,
+        });
+      } catch (err) {
+        console.error("Failed to load topics:", err);
+        set({ error: "Failed to load topics.", initialized: true });
+      } finally {
+        set({ loading: false });
+      }
+    },
+
+    loadMore: async () => {
+      const { loading, hasMore, currentPage } = get();
+      if (loading || !hasMore) return;
+
+      set({ loading: true });
+      try {
+        const nextPage = currentPage + 1;
+        const data = await getPublicTags(nextPage, TOPIC_PAGE_SIZE);
+        set((state) => ({
+          topics: mergeTags(state.topics, data.tags),
+          currentPage: data.currentPage,
+          hasMore: data.hasMore,
+          error: null,
+        }));
+      } catch (err) {
+        console.error("Failed to load more topics:", err);
+        set({ error: "Failed to load more topics." });
+      } finally {
+        set({ loading: false });
+      }
+    },
+  })
+);
+
+/**
+ * Seed the shared topic store from a server-rendered first page, once per
+ * load. Call at the page level so the cloud paints without a client fetch.
+ */
+export function useHydrateTopicCloud(firstPage?: PaginatedTagsResponse) {
+  const hydrate = useTopicCloudStore((s) => s.hydrate);
+  useEffect(() => {
+    if (firstPage) hydrate(firstPage);
+  }, [firstPage, hydrate]);
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useScrollSpy } from "./use-scroll-spy";
 export { useIntersectionObserver } from "./use-intersection-observer";
+export { useInfiniteScroll } from "./use-infinite-scroll";
 export { useScrollDirection } from "./use-scroll-direction";
 export { useWindowSize } from "./use-window-size";
 export { useAuth } from "@/features/auth/hooks/useAuth";

--- a/src/hooks/use-infinite-scroll/index.ts
+++ b/src/hooks/use-infinite-scroll/index.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+interface UseInfiniteScrollOptions {
+  onLoadMore: () => void;
+  hasMore: boolean;
+  loading: boolean;
+  /** Scroll container to observe within; omit to observe the viewport. */
+  rootRef?: RefObject<HTMLElement | null>;
+  /** Prefetch margin so the next batch starts before the very edge. */
+  rootMargin?: string;
+  /**
+   * Bump whenever the list length changes so the observer re-evaluates
+   * against the new layout — this drives "keep loading while the sentinel
+   * stays visible" using a fresh reading instead of a stale one.
+   */
+  resetKey?: number;
+}
+
+/**
+ * Auto-loads the next batch when a sentinel enters view. Loading is triggered
+ * from the intersection callback (reading the latest state via a ref), so it
+ * never fires on a stale `loading` transition; re-observing on `resetKey`
+ * continues loading short lists and stops once the sentinel is scrolled past.
+ * Attach the returned ref to a sentinel at the end of the list.
+ */
+export function useInfiniteScroll({
+  onLoadMore,
+  hasMore,
+  loading,
+  rootRef,
+  rootMargin = "200px",
+  resetKey = 0,
+}: UseInfiniteScrollOptions) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const latest = useRef({ onLoadMore, hasMore, loading });
+
+  // Keep the latest state in a ref (outside render) so the intersection
+  // callback always reads current values without re-creating the observer.
+  useEffect(() => {
+    latest.current = { onLoadMore, hasMore, loading };
+  });
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const { onLoadMore: load, hasMore: more, loading: busy } =
+          latest.current;
+        if (entry.isIntersecting && more && !busy) {
+          load();
+        }
+      },
+      { root: rootRef?.current ?? null, rootMargin }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [rootRef, rootMargin, resetKey]);
+
+  return sentinelRef;
+}

--- a/src/lib/blogUtils.ts
+++ b/src/lib/blogUtils.ts
@@ -111,15 +111,6 @@ export function estimateReadTime(html: string): string {
 }
 
 /**
- * Unique, non-empty tags across a set of posts (insertion order preserved).
- */
-export function getUniqueTags(posts: Pick<BlogPost, "tags">[]): string[] {
-  return Array.from(
-    new Set(posts.flatMap((post) => post.tags || []).filter(Boolean))
-  );
-}
-
-/**
  * Format a date string for display (e.g., "Jan 15, 2025")
  */
 export function formatDate(dateString: string): string {

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -331,6 +331,24 @@ export interface AdjacentBlogs {
   older: BlogPost | null;
 }
 
+/** A topic in the cloud; `postCount` drives visual weighting. */
+export interface BlogTag {
+  id: Uuid;
+  name: string;
+  slug: string;
+  postCount: number;
+}
+
+/** `blog_public_tags_list` jsonb envelope (camelCase, matches blog list convention). */
+export interface PaginatedTagsResponse {
+  tags: BlogTag[];
+  totalCount: number;
+  /** Highest postCount in the capped set; constant across pages, for weighting. */
+  maxPostCount: number;
+  hasMore: boolean;
+  currentPage: number;
+}
+
 /** Public list/search RPC jsonb: camelCase envelope keys (see `blogRowJson` wire note). */
 export interface PaginatedBlogsResponse {
   blogs: BlogPost[];

--- a/supabase/migrations/20260714000100_blogs_rpc_tags_public.sql
+++ b/supabase/migrations/20260714000100_blogs_rpc_tags_public.sql
@@ -1,0 +1,94 @@
+-- =============================================================================
+-- Public tag-cloud RPC — weighted, popularity-capped, alphabetically paginated
+-- =============================================================================
+-- Powers the site's Topic Cloud. Ranks tags by number of PUBLISHED posts
+-- (the JOIN to published blogs is the published-only filter), keeps the top
+-- N most popular, then serves that capped set in alphabetical pages so the
+-- cloud fills in A–Z as it infinite-scrolls — no reshuffle between batches.
+-- Each row carries postCount so the client can weight (size) each topic.
+
+CREATE OR REPLACE FUNCTION public.blog_public_tags_list(
+  p_page int DEFAULT 1,
+  p_limit int DEFAULT 10,
+  p_cap int DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH params AS (
+    SELECT
+      GREATEST(COALESCE(p_page, 1), 1) AS page,
+      LEAST(GREATEST(COALESCE(p_limit, 10), 1), 100) AS lim,
+      LEAST(GREATEST(COALESCE(p_cap, 30), 1), 200) AS cap
+  ),
+  ranked AS (
+    -- Published-post count per tag (INNER JOIN drops tags with none),
+    -- ranked most-popular first for the cap.
+    SELECT
+      t.id,
+      t.name,
+      t.slug,
+      count(b.id)::int AS post_count,
+      row_number() OVER (
+        ORDER BY count(b.id) DESC, lower(t.name), t.id
+      ) AS pop_rank
+    FROM public.blog_tags t
+    JOIN public.blog_tag_links l ON l.tag_id = t.id
+    JOIN public.blogs b ON b.id = l.blog_id AND b.status = 'published'
+    GROUP BY t.id, t.name, t.slug
+  ),
+  top AS (
+    -- Keep the most popular `cap` tags, then number them alphabetically so
+    -- pages are stable A–Z slices of that capped set.
+    SELECT
+      id,
+      name,
+      slug,
+      post_count,
+      row_number() OVER (ORDER BY lower(name), id) AS alpha_rank
+    FROM ranked, params
+    WHERE pop_rank <= params.cap
+  )
+  SELECT jsonb_build_object(
+    'tags',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            '_id', top.id,
+            'id', top.id,
+            'name', top.name,
+            'slug', top.slug,
+            'postCount', top.post_count
+          )
+          ORDER BY top.alpha_rank
+        )
+        FROM top, params
+        WHERE top.alpha_rank > (params.page - 1) * params.lim
+          AND top.alpha_rank <= params.page * params.lim
+      ),
+      '[]'::jsonb
+    ),
+    'totalCount', (SELECT count(*)::int FROM top),
+    -- Constant across pages: lets the client weight topics relatively and
+    -- keep sizes stable as batches stream in.
+    'maxPostCount', (SELECT COALESCE(max(post_count), 0)::int FROM top),
+    'currentPage', (SELECT page FROM params),
+    'hasMore', (
+      SELECT (page * lim) < (SELECT count(*)::int FROM top) FROM params
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION public.blog_public_tags_list(int, int, int) IS
+  'Public topic-cloud RPC. Args: p_page int default 1, p_limit int default 10 (capped 100), p_cap int default 30 (capped 200). Ranks tags by published-post count desc, keeps the top p_cap, and returns that set paginated alphabetically: {"tags":[{"_id":"uuid","id":"uuid","name":"text","slug":"text","postCount":"int"}],"totalCount":"int (size of capped set)","maxPostCount":"int (highest count in the set; for relative weighting)","currentPage":"int","hasMore":"boolean"}. Only tags with >=1 published post appear.';
+
+REVOKE ALL ON FUNCTION public.blog_public_tags_list(int, int, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.blog_public_tags_list(int, int, int) TO anon, authenticated;
+
+-- =============================================================================
+-- Migration Complete
+-- =============================================================================


### PR DESCRIPTION
## Summary

The topic cloud previously derived tags from the posts that happened to be loaded on the page, so it was incomplete and drifted between the listing and article pages. This PR makes it load from a **canonical, server-ranked source**: the top ~30 topics by popularity, displayed A–Z, sized by post count, and streamed in alphabetical batches via infinite scroll inside a bounded panel.

## What changed

**Data / RPC**
- New migration `blog_public_tags_list(p_page, p_limit, p_cap)` — ranks published-blog tags by post count, caps at 30, orders the capped set A–Z, and paginates. Returns `maxPostCount` alongside the batch so badge weighting stays stable as pages stream in.

**Service layer**
- Added `BlogTag` / `PaginatedTagsResponse` types.
- Added `getPublicTags(page, limit)` across the real, dummy, and resolved service implementations (dummy mirrors the same rank → cap 30 → A–Z logic so dummy mode works without a database).

**State (Zustand)**
- New shared `topicCloudStore` with idempotent `hydrate` / `ensureLoaded` and a guarded `loadMore`. The listing page and the article page share **one** fetch instead of each harvesting their own tags.

**UI**
- Extracted a reusable `useInfiniteScroll` hook — the load is triggered from the IntersectionObserver callback (reading the latest state via a ref updated in an effect) and re-observes on a `resetKey`, so short lists stream in batches without the stale-`loading` race.
- Extracted `TopicBadge`, which sizes each pill by `postCount / maxPostCount` (weighted cloud, four buckets).
- `TopicCloud` now composes the store + hook + badge; it renders a bounded, scrollable panel with a sentinel.

**Cleanup (DRY / SRP)**
- Removed the now-dead post-derived tag paths: `getUniqueTags` and the `allTags` state from both the listing and detail stores. Topics now have a single canonical source, so there's no drift between two mechanisms.

## Verification
- `yarn lint` — 0 errors (8 pre-existing warnings, all unrelated).
- `yarn build` — passes in dummy mode.
- Batching confirmed manually: 10 → 20 on mount, 20 → 30 on scroll, capped at 30; weighted A–Z rendering.

## Note on the migration
The SQL migration could not be runtime-tested in this environment (container images can't be pulled here, so `supabase start` / `db reset` won't run). It needs a `db:push` / `db reset` against reachable Postgres to activate. **Dummy mode works today** via the fixture-derived tags, so the UI is fully exercisable without the migration applied.
