### PR TITLE
chore(config): sanitize Supabase project ref in example/config files

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "supabase": {
-      "url": "https://mcp.supabase.com/mcp?project_ref=hdzkewhdohwimbfgoxcu"
+      "url": "https://mcp.supabase.com/mcp?project_ref=<project-ref>"
     }
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 
 # Supabase API URL from MCP `get_project_url` (do not use DB URL here)
-NEXT_PUBLIC_SUPABASE_URL=https://hdzkewhdohwimbfgoxcu.supabase.co
+NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
 # Supabase key from MCP `get_publishable_keys`:
 # - This app currently expects the legacy anon JWT format (`xxxxx.yyyyy.zzzzz`)
 # - Use the key with name "anon" (type: legacy)
@@ -14,7 +14,7 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 # Supabase Postgres (server-side direct DB connection only)
 # This is a Postgres URI and is different from NEXT_PUBLIC_SUPABASE_URL.
-# host: db.hdzkewhdohwimbfgoxcu.supabase.co
+# host: db.<project-ref>.supabase.co
 # port: 5432
 # database: postgres
 # user: postgres

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:local:migrate": "npx supabase migration list 2>&1",
     "db:local:reset": "npx supabase db reset 2>&1",
     "db:remote:reset": "npx supabase db reset --linked 2>&1",
+    "db:remote:push": "npx supabase db push --linked 2>&1",
     "db:verify:rbac-e2e": "npx supabase db reset --no-seed 2>&1 && psql \"postgresql://postgres:postgres@127.0.0.1:54322/postgres\" -v ON_ERROR_STOP=1 -f supabase/verify/verify_rbac_e2e.sql 2>&1"
   },
   "dependencies": {


### PR DESCRIPTION
## What

Two small config/tooling changes:

**1. Sanitize the real Supabase project ref** (replace with a `<project-ref>` placeholder so it is not committed):
- `.env.example` — `NEXT_PUBLIC_SUPABASE_URL` and the `host:` comment, consistent with the existing `DATABASE_URL` placeholder on the same file.
- `.cursor/mcp.json` — the `project_ref` query param.

**2. Add a `db:remote:push` script** — `supabase db push --linked` — the safe, append-only way to apply pending migrations to the linked remote, distinct from the destructive `db:remote:reset`.

## Why

- The concrete project ref was hard-coded in example/config files; scrubbing it keeps a real identifier out of version control.
- There was no non-destructive npm script for pushing migrations to the remote — only `db:remote:reset`, which wipes and rebuilds the database.

## Note

`.cursor/mcp.json` is a live MCP config — after this lands, the real ref must be restored locally (and ideally git-ignored) for the Cursor Supabase MCP to keep connecting.