### PR TITLE
fix(blog): render /blog dynamically so published posts always show

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,6 +10,15 @@ import { TOPIC_PAGE_SIZE } from "@/features/blog/topicCloudStore";
 
 export const metadata: Metadata = homeMetadata;
 
+// Render at request time, not build time. The default (unfiltered) listing is
+// served from this server payload — the client only re-fetches when a tag /
+// category / search filter is active. Without this, Next.js statically renders
+// the page at build time and freezes whatever posts existed then (often none),
+// so newly published posts never appear on /blog even though tag/topic views
+// (which fetch live on the client) do. Use `revalidate = N` instead if you
+// prefer ISR caching over always-fresh rendering.
+export const dynamic = "force-dynamic";
+
 export default async function BlogListingPage() {
   // Fetch initial data server-side (where process.env[key] works correctly)
   const [initialBlogs, initialCategories, initialTags] = await Promise.all([


### PR DESCRIPTION
## Problem

The main blog listing at `/blog` showed **"No articles found — No articles have been published yet"**, even though:
- the **Topic Cloud** loads tags correctly, and
- **tag-filtered** views (e.g. `/blog?tag=Accessibility`) show published posts.

## Root cause

It is **not** a Supabase URL/connection issue — the topic cloud and tag filter both hit the same database successfully, and `blog_public_list_by_tag` internally calls `blog_public_list_published` (the tag result is a strict subset of the unfiltered result), so the RPC/data can't be the cause.

The real cause is **render mode**:

- The unfiltered listing is served from the **server payload** fetched in the `/blog` server component (`getBlogsPaginated()`).
- The client store only re-fetches when a **tag / category / search** filter is active — the default view relies entirely on the server data (`BlogPage.tsx` initial-render guard).
- `src/app/blog/page.tsx` had **no `dynamic` / `revalidate`** export and reads no request data, so Next.js **statically rendered it at build time**. `getBlogsPaginated()` ran once at build (when no posts existed / a different project was configured) and that empty result was frozen into the page.

The topic cloud and tag-filter views work because they fetch **live on the client** at runtime.

## Fix

```ts
export const dynamic = "force-dynamic";
```

on `src/app/blog/page.tsx`, so the listing is server-rendered at request time and always reflects currently-published posts. (Switch to `export const revalidate = N` if ISR caching is preferred over always-fresh rendering.)

## Verification

`next build` route table — `/blog` flips from Static to Dynamic:

```
├ ƒ /blog            (was ○ Static)
ƒ (Dynamic)  server-rendered on demand
```

Build compiles cleanly; no type errors.

## Note

Requires a redeploy to take effect on the live site.