### PR TITLE
Support multi-tag filtering with OR/union semantics in blog listing

### DIFF
--- a/src/features/blog/BlogDetailPage.tsx
+++ b/src/features/blog/BlogDetailPage.tsx
@@ -92,7 +92,7 @@ export function BlogDetailPage({
   }, [post, initializePost, fetchRelatedPosts, trackView, reset]);
 
   const handleTagClick = (tag: string) => {
-    router.push(`/blog?tag=${encodeURIComponent(tag)}`);
+    router.push(`/blog?tags=${encodeURIComponent(tag)}`);
   };
 
   const handleSearch = (query: string) => {
@@ -338,7 +338,7 @@ export function BlogDetailPage({
                 onCategoryChange={handleCategoryChange}
                 isSearchActive={false}
                 onTagClick={handleTagClick}
-                activeTag={null}
+                activeTags={[]}
               />
             </div>
           </aside>

--- a/src/features/blog/BlogPage.tsx
+++ b/src/features/blog/BlogPage.tsx
@@ -54,7 +54,7 @@ export function BlogPage({
     blogs,
     blogCategories,
     activeCategory,
-    activeTag,
+    activeTags,
     searchQuery,
     sortBy,
     hasMorePosts,
@@ -72,7 +72,7 @@ export function BlogPage({
   } = useBlogListingStore();
 
   // ─── URL-synced filter actions ───
-  const { onCategoryChange, onTagChange, onSearch, onClearSearch, onClearAllFilters } =
+  const { onCategoryChange, onTagToggle, onSearch, onClearSearch, onClearAllFilters } =
     useBlogUrlParams();
 
   const prefersReducedMotion = useReducedMotion();
@@ -94,17 +94,20 @@ export function BlogPage({
 
   // Fetch blogs when filters change (skip initial only if no URL params are active,
   // since server data is unfiltered)
+  // Join the tags into a stable primitive so the effect only re-runs when the
+  // selection actually changes (not on every render's fresh array reference).
+  const activeTagsKey = activeTags.join(",");
   const initialRender = useRef(true);
   useEffect(() => {
     if (initialRender.current) {
       initialRender.current = false;
       // If a filter is already active from URL params, fetch filtered data
-      if (activeCategory === "all" && !activeTag && !searchQuery) {
+      if (activeCategory === "all" && !activeTagsKey && !searchQuery) {
         return;
       }
     }
     fetchFilteredBlogs();
-  }, [activeCategory, activeTag, searchQuery, fetchFilteredBlogs]);
+  }, [activeCategory, activeTagsKey, searchQuery, fetchFilteredBlogs]);
 
   // Access-denied redirect notice — reads location.search in an effect so the
   // page stays prerenderable (see useBlogUrlParams for the same constraint).
@@ -173,7 +176,7 @@ export function BlogPage({
   }, [displayBlogs, sortBy]);
 
   const hasActiveFilters =
-    Boolean(searchQuery.trim()) || Boolean(activeTag) || activeCategory !== "all";
+    Boolean(searchQuery.trim()) || activeTags.length > 0 || activeCategory !== "all";
 
   const showingMeta =
     !isContentLoading && !error && filteredPosts.length > 0
@@ -212,20 +215,35 @@ export function BlogPage({
           </div>
         )}
 
-        {activeTag && (
+        {activeTags.length > 0 && (
           <div className="max-w-6xl mx-auto px-4 mt-4 pb-2">
-            <div className="flex items-center gap-2">
-              <span className="text-meta">Filtering by tag:</span>
-              <Badge variant="default" className="gap-1">
-                #{activeTag}
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-meta">
+                {activeTags.length === 1
+                  ? "Filtering by topic:"
+                  : "Filtering by topics:"}
+              </span>
+              {activeTags.map((tag) => (
+                <Badge key={tag} variant="default" className="gap-1">
+                  #{tag}
+                  <button
+                    onClick={() => onTagToggle(tag)}
+                    className="ml-1 hover:text-primary-foreground/80"
+                    title={`Remove ${tag}`}
+                    aria-label={`Remove ${tag} filter`}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+              {activeTags.length > 1 && (
                 <button
                   onClick={onClearAllFilters}
-                  className="ml-1 hover:text-primary-foreground/80"
-                  title="Clear tag filter"
+                  className="text-sm text-muted-foreground underline hover:text-primary"
                 >
-                  <X className="h-3 w-3" />
+                  Clear all
                 </button>
-              </Badge>
+              )}
             </div>
           </div>
         )}
@@ -328,8 +346,8 @@ export function BlogPage({
                 activeCategory={activeCategory}
                 onCategoryChange={onCategoryChange}
                 isSearchActive={!!searchQuery.trim()}
-                onTagClick={onTagChange}
-                activeTag={activeTag}
+                onTagClick={onTagToggle}
+                activeTags={activeTags}
               />
             </div>
           </aside>
@@ -380,14 +398,12 @@ export function BlogPage({
             label: "Topics",
             icon: <Tag />,
             title: "Topic Cloud",
-            active: Boolean(activeTag),
-            content: (close) => (
+            active: activeTags.length > 0,
+            content: () => (
               <TopicCloud
-                activeTag={activeTag}
-                onTagClick={(tag) => {
-                  onTagChange(tag);
-                  close();
-                }}
+                activeTags={activeTags}
+                // Keep the sheet open so several topics can be toggled at once.
+                onTagClick={onTagToggle}
               />
             ),
           },

--- a/src/features/blog/components/BlogSidebar.tsx
+++ b/src/features/blog/components/BlogSidebar.tsx
@@ -7,7 +7,7 @@ import { TopicCloud } from "./TopicCloud";
 
 export interface BlogSidebarProps {
   onTagClick?: (tag: string) => void;
-  activeTag?: string | null;
+  activeTags?: string[];
   categories?: BlogCategory[];
   activeCategory?: string;
   onCategoryChange?: (categoryId: string) => void;
@@ -18,7 +18,7 @@ export interface BlogSidebarProps {
 
 export function BlogSidebar({
   onTagClick,
-  activeTag,
+  activeTags,
   categories,
   activeCategory,
   onCategoryChange,
@@ -59,7 +59,7 @@ export function BlogSidebar({
           <h3 className="text-eyebrow">Topic Cloud</h3>
         </CardHeader>
         <CardContent>
-          <TopicCloud activeTag={activeTag} onTagClick={onTagClick} />
+          <TopicCloud activeTags={activeTags} onTagClick={onTagClick} />
         </CardContent>
       </Card>
     </div>

--- a/src/features/blog/components/TopicBadge.tsx
+++ b/src/features/blog/components/TopicBadge.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface TopicBadgeProps {
@@ -42,14 +43,16 @@ export function TopicBadge({
       type="button"
       onClick={onClick}
       title={`${postCount} ${postCount === 1 ? "article" : "articles"}`}
+      aria-pressed={active}
       className={cn(
-        "pressable rounded-full border transition-colors duration-150",
+        "pressable inline-flex items-center gap-1 rounded-full border transition-colors duration-150",
         weightClass(postCount, maxPostCount),
         active
           ? "border-primary bg-primary text-primary-foreground"
           : "border-border bg-secondary text-secondary-foreground hover:border-primary/50 hover:text-primary"
       )}
     >
+      {active && <Check className="h-3 w-3" aria-hidden />}
       {name}
     </button>
   );

--- a/src/features/blog/components/TopicCloud.tsx
+++ b/src/features/blog/components/TopicCloud.tsx
@@ -8,7 +8,8 @@ import { useTopicCloudStore } from "../topicCloudStore";
 import { TopicBadge } from "./TopicBadge";
 
 interface TopicCloudProps {
-  activeTag?: string | null;
+  /** Currently selected topics (OR filter) — badges for these render active. */
+  activeTags?: string[];
   onTagClick?: (tag: string) => void;
 }
 
@@ -17,7 +18,7 @@ interface TopicCloudProps {
  * listing and article pages share one fetch) and infinite-scrolls the capped
  * set in alphabetical batches inside its own bounded panel.
  */
-export function TopicCloud({ activeTag, onTagClick }: TopicCloudProps) {
+export function TopicCloud({ activeTags = [], onTagClick }: TopicCloudProps) {
   const { topics, maxPostCount, hasMore, loading, initialized, error } =
     useTopicCloudStore();
   const ensureLoaded = useTopicCloudStore((s) => s.ensureLoaded);
@@ -66,7 +67,7 @@ export function TopicCloud({ activeTag, onTagClick }: TopicCloudProps) {
               name={topic.name}
               postCount={topic.postCount}
               maxPostCount={maxPostCount}
-              active={activeTag === topic.name}
+              active={activeTags.includes(topic.name)}
               onClick={() => onTagClick?.(topic.name)}
             />
           ))}

--- a/src/features/blog/services/blogService.ts
+++ b/src/features/blog/services/blogService.ts
@@ -107,33 +107,24 @@ export async function getBlogsByCategory(
   return parsePaginatedBlogs(data);
 }
 
-export async function getBlogsByTag(
-  tag: string,
+export async function getBlogsByTags(
+  tags: string[],
   page: number = 1,
   limit: number = 10
-): Promise<PaginatedBlogsResponse & { filters: Record<string, unknown> }> {
+): Promise<PaginatedBlogsResponse> {
   const supabase = createClient();
-  const { data, error } = await supabase.rpc("blog_public_list_by_tag", {
-    p_tag_slug: tag,
+  const { data, error } = await supabase.rpc("blog_public_list_by_tags", {
+    p_tag_slugs: tags,
     p_page: page,
     p_limit: limit,
     p_sort: "newest",
   });
 
   if (error) {
-    throw new Error(error.message || "Failed to fetch blogs by tag.");
+    throw new Error(error.message || "Failed to fetch blogs by tags.");
   }
 
-  const paginated = parsePaginatedBlogs(data);
-  const payload = assertRpcObject(data, "Invalid blogs-by-tag response.");
-
-  return {
-    ...paginated,
-    filters:
-      payload.filters && typeof payload.filters === "object"
-        ? (payload.filters as Record<string, unknown>)
-        : {},
-  };
+  return parsePaginatedBlogs(data);
 }
 
 export async function searchBlogsByTitle(

--- a/src/features/blog/services/dummyBlogService.ts
+++ b/src/features/blog/services/dummyBlogService.ts
@@ -97,18 +97,23 @@ export async function getBlogsByCategory(
   return paginate(filtered, page, limit);
 }
 
-export async function getBlogsByTag(
-  tag: string,
+export async function getBlogsByTags(
+  tags: string[],
   page: number = 1,
-  limit: number = 10,
-  _sortBy?: string,
-  _sortOrder?: string,
-  _status?: string
-): Promise<PaginatedBlogsResponse & { filters: Record<string, unknown> }> {
-  const filtered = dummyBlogs.filter((b) =>
-    b.tags.some((t) => t.toLowerCase() === tag.toLowerCase())
+  limit: number = 10
+): Promise<PaginatedBlogsResponse> {
+  const needles = new Set(
+    tags.map((t) => t.trim().toLowerCase()).filter(Boolean)
   );
-  return { ...paginate(filtered, page, limit), filters: {} };
+  // Empty selection = no tag filter (mirrors the RPC), so return everything.
+  const matched =
+    needles.size === 0
+      ? dummyBlogs
+      : dummyBlogs.filter((b) =>
+          // OR / union: a post matches if it carries any selected tag.
+          b.tags.some((t) => needles.has(t.toLowerCase()))
+        );
+  return paginate(sortByNewest(matched), page, limit);
 }
 
 export async function searchBlogsByTitle(

--- a/src/features/blog/services/resolvedBlogService.ts
+++ b/src/features/blog/services/resolvedBlogService.ts
@@ -9,7 +9,7 @@ type BlogApiContract = {
   getBlogById: typeof blogApi.getBlogById;
   getBlogBySlug: typeof blogApi.getBlogBySlug;
   getBlogsByCategory: typeof blogApi.getBlogsByCategory;
-  getBlogsByTag: typeof blogApi.getBlogsByTag;
+  getBlogsByTags: typeof blogApi.getBlogsByTags;
   searchBlogsByTitle: typeof blogApi.searchBlogsByTitle;
   likeBlog: typeof blogApi.likeBlog;
   getAdjacentBlogs: typeof blogApi.getAdjacentBlogs;
@@ -26,7 +26,7 @@ export const getBlogsPaginated = resolved.getBlogsPaginated;
 export const getBlogById = resolved.getBlogById;
 export const getBlogBySlug = resolved.getBlogBySlug;
 export const getBlogsByCategory = resolved.getBlogsByCategory;
-export const getBlogsByTag = resolved.getBlogsByTag;
+export const getBlogsByTags = resolved.getBlogsByTags;
 export const searchBlogsByTitle = resolved.searchBlogsByTitle;
 export const likeBlog = resolved.likeBlog;
 export const getAdjacentBlogs = resolved.getAdjacentBlogs;

--- a/src/features/blog/store.ts
+++ b/src/features/blog/store.ts
@@ -6,7 +6,7 @@ import {
   getAllBlogCategories,
   getBlogsPaginated,
   getBlogsByCategory,
-  getBlogsByTag,
+  getBlogsByTags,
   searchBlogsByTitle,
 } from "./services/resolvedBlogService";
 
@@ -21,7 +21,8 @@ interface BlogListingState {
 
   // Filters
   activeCategory: string;
-  activeTag: string | null;
+  /** Selected topic filter — OR/union semantics (a post matches any of these). */
+  activeTags: string[];
   searchQuery: string;
   sortBy: SortOption;
 
@@ -59,7 +60,7 @@ interface BlogListingActions {
 
   // Filter actions
   setActiveCategory: (categoryId: string) => void;
-  setActiveTag: (tag: string | null) => void;
+  setActiveTags: (tags: string[]) => void;
   setSearchQuery: (query: string) => void;
   setSortBy: (sort: SortOption) => void;
 
@@ -67,11 +68,12 @@ interface BlogListingActions {
   handleSearch: (query: string) => void;
   clearSearch: () => void;
   handleCategoryChange: (categoryId: string) => void;
-  handleTagChange: (tag: string) => void;
+  /** Replace the topic filter with `tags` (clears category/search, resets page). */
+  applyTagFilter: (tags: string[]) => void;
   clearAllFilters: () => void;
 
   // Hydration from URL params
-  hydrateFromParams: (params: { tag?: string | null; category?: string | null; search?: string | null }) => void;
+  hydrateFromParams: (params: { tags?: string[] | null; category?: string | null; search?: string | null }) => void;
 }
 
 // ─── Constants ───
@@ -86,7 +88,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     blogs: [],
     blogCategories: [],
     activeCategory: "all",
-    activeTag: null,
+    activeTags: [],
     searchQuery: "",
     sortBy: "newest",
     currentPage: 1,
@@ -148,7 +150,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     },
 
     fetchFilteredBlogs: async (source = "initial") => {
-      const { activeCategory, activeTag, searchQuery, blogCategories } = get();
+      const { activeCategory, activeTags, searchQuery, blogCategories } = get();
 
       // Set loading state based on source
       const loadingUpdate: Partial<BlogListingState> = {};
@@ -172,8 +174,8 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
 
         if (searchQuery.trim()) {
           data = await searchBlogsByTitle(searchQuery.trim(), 1, POSTS_PER_PAGE);
-        } else if (activeTag) {
-          data = await getBlogsByTag(activeTag, 1, POSTS_PER_PAGE);
+        } else if (activeTags.length > 0) {
+          data = await getBlogsByTags(activeTags, 1, POSTS_PER_PAGE);
         } else if (activeCategory && activeCategory !== "all") {
           const category = blogCategories.find((cat) => cat.id === activeCategory);
           if (category) {
@@ -215,7 +217,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     },
 
     loadMorePosts: async () => {
-      const { loadingMore, hasMorePosts, currentPage, searchQuery, activeCategory, blogCategories, blogs } = get();
+      const { loadingMore, hasMorePosts, currentPage, searchQuery, activeTags, activeCategory, blogCategories, blogs } = get();
       if (loadingMore || !hasMorePosts) return;
 
       set({ loadingMore: true });
@@ -226,6 +228,8 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
 
         if (searchQuery.trim()) {
           response = await searchBlogsByTitle(searchQuery, nextPage, POSTS_PER_PAGE);
+        } else if (activeTags.length > 0) {
+          response = await getBlogsByTags(activeTags, nextPage, POSTS_PER_PAGE);
         } else if (activeCategory !== "all") {
           const selectedCategory = blogCategories.find((cat) => cat.id === activeCategory);
           if (selectedCategory) {
@@ -255,7 +259,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
     // ─── Filter Actions ───
 
     setActiveCategory: (categoryId) => set({ activeCategory: categoryId }),
-    setActiveTag: (tag) => set({ activeTag: tag }),
+    setActiveTags: (tags) => set({ activeTags: tags }),
     setSearchQuery: (query) => set({ searchQuery: query }),
     setSortBy: (sort) => set({ sortBy: sort }),
 
@@ -268,6 +272,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
         currentPage: 1,
         error: null,
         activeCategory: query.trim() && state.activeCategory !== "all" ? "all" : state.activeCategory,
+        activeTags: query.trim() ? [] : state.activeTags,
       });
       // Fetch is triggered by the component via useEffect watching searchQuery
     },
@@ -281,14 +286,14 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
         activeCategory: categoryId,
         currentPage: 1,
         error: null,
-        activeTag: null,
+        activeTags: [],
         searchQuery: "",
       });
     },
 
-    handleTagChange: (tag) => {
+    applyTagFilter: (tags) => {
       set({
-        activeTag: tag,
+        activeTags: tags,
         currentPage: 1,
         error: null,
         searchQuery: "",
@@ -300,21 +305,21 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
       set({
         searchQuery: "",
         activeCategory: "all",
-        activeTag: null,
+        activeTags: [],
         currentPage: 1,
         error: null,
       });
     },
 
-    hydrateFromParams: ({ tag, category, search }) => {
+    hydrateFromParams: ({ tags, category, search }) => {
       const updates: Partial<BlogListingState> = {};
 
       if (search) {
         updates.searchQuery = search;
         updates.activeCategory = "all";
-        updates.activeTag = null;
-      } else if (tag) {
-        updates.activeTag = tag;
+        updates.activeTags = [];
+      } else if (tags && tags.length > 0) {
+        updates.activeTags = tags;
         updates.activeCategory = "all";
         updates.searchQuery = "";
       } else if (category) {
@@ -329,7 +334,7 @@ export const useBlogListingStore = create<BlogListingState & BlogListingActions>
           // If categories aren't loaded yet, store the name and resolve later
           updates.activeCategory = category;
         }
-        updates.activeTag = null;
+        updates.activeTags = [];
         updates.searchQuery = "";
       }
 

--- a/src/hooks/use-blog-url-params/index.ts
+++ b/src/hooks/use-blog-url-params/index.ts
@@ -19,8 +19,9 @@ export function useBlogUrlParams() {
 
   const {
     blogCategories,
+    activeTags,
     handleCategoryChange,
-    handleTagChange,
+    applyTagFilter,
     handleSearch,
     clearSearch,
     clearAllFilters,
@@ -35,13 +36,14 @@ export function useBlogUrlParams() {
   useEffect(() => {
     const syncFromLocation = () => {
       const params = new URLSearchParams(window.location.search);
-      const tagParam = params.get("tag");
+      // Prefer the multi-tag `tags=a,b`; fall back to the legacy single `tag=a`.
+      const tags = parseTagsParam(params.get("tags") ?? params.get("tag"));
       const categoryParam = params.get("category");
       const searchParam = params.get("search");
 
-      if (tagParam || categoryParam || searchParam) {
+      if (tags.length > 0 || categoryParam || searchParam) {
         hydrateFromParams({
-          tag: tagParam,
+          tags,
           category: categoryParam,
           search: searchParam,
         });
@@ -55,7 +57,7 @@ export function useBlogUrlParams() {
 
   // ── Helper: push current filter state into the URL ──────────────────────
   const updateUrlParams = useCallback(
-    (params: { category?: string; tag?: string | null; search?: string }) => {
+    (params: { category?: string; tags?: string[]; search?: string }) => {
       const newParams = new URLSearchParams();
 
       if (params.category && params.category !== "all") {
@@ -63,8 +65,8 @@ export function useBlogUrlParams() {
         const cat = blogCategories.find((c) => c.id === params.category);
         newParams.set("category", cat ? cat.name : params.category);
       }
-      if (params.tag) {
-        newParams.set("tag", params.tag);
+      if (params.tags && params.tags.length > 0) {
+        newParams.set("tags", params.tags.join(","));
       }
       if (params.search) {
         newParams.set("search", params.search);
@@ -85,12 +87,16 @@ export function useBlogUrlParams() {
     [handleCategoryChange, updateUrlParams],
   );
 
-  const onTagChange = useCallback(
+  // Toggle a topic in/out of the OR-filter, then mirror the result to the URL.
+  const onTagToggle = useCallback(
     (tag: string) => {
-      handleTagChange(tag);
-      updateUrlParams({ tag });
+      const next = activeTags.includes(tag)
+        ? activeTags.filter((t) => t !== tag)
+        : [...activeTags, tag];
+      applyTagFilter(next);
+      updateUrlParams({ tags: next });
     },
-    [handleTagChange, updateUrlParams],
+    [activeTags, applyTagFilter, updateUrlParams],
   );
 
   const onSearch = useCallback(
@@ -113,9 +119,24 @@ export function useBlogUrlParams() {
 
   return {
     onCategoryChange,
-    onTagChange,
+    onTagToggle,
     onSearch,
     onClearSearch,
     onClearAllFilters,
   };
+}
+
+/** Parse a `tags`/`tag` query value ("a,b,c") into a trimmed, de-duped list. */
+function parseTagsParam(raw: string | null): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const part of raw.split(",")) {
+    const tag = part.trim();
+    if (tag && !seen.has(tag)) {
+      seen.add(tag);
+      result.push(tag);
+    }
+  }
+  return result;
 }

--- a/supabase/migrations/20260716000100_blogs_rpc_by_tags.sql
+++ b/supabase/migrations/20260716000100_blogs_rpc_by_tags.sql
@@ -1,0 +1,121 @@
+-- Multi-tag public blog listing (OR / union semantics).
+--
+-- Mirrors blog_public_list_published's envelope, sort, and pagination but
+-- filters on an ARRAY of tag slugs/names: a post is included when it carries
+-- at least one of the requested tags. Empty/NULL array = no tag filter (all
+-- published posts), so callers can reuse it as a general list too.
+--
+-- SECURITY INVOKER + SET search_path, published-only, granted to anon/auth,
+-- matching the rest of the public RPCs.
+
+CREATE OR REPLACE FUNCTION public.blog_public_list_by_tags(
+  p_tag_slugs text[] DEFAULT NULL,
+  p_page int DEFAULT 1,
+  p_limit int DEFAULT 10,
+  p_sort text DEFAULT 'newest'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_page int := GREATEST(COALESCE(p_page, 1), 1);
+  v_limit int := LEAST(GREATEST(COALESCE(p_limit, 10), 1), 100);
+  v_offset int := (GREATEST(COALESCE(p_page, 1), 1) - 1) * LEAST(GREATEST(COALESCE(p_limit, 10), 1), 100);
+  v_sort text := lower(COALESCE(NULLIF(trim(p_sort), ''), 'newest'));
+  -- Normalise to a lowercased set of non-empty needles; NULL when none given.
+  v_slugs text[] := (
+    SELECT CASE WHEN count(*) > 0 THEN array_agg(s) END
+    FROM (
+      SELECT DISTINCT lower(trim(x)) AS s
+      FROM unnest(COALESCE(p_tag_slugs, ARRAY[]::text[])) AS x
+      WHERE NULLIF(trim(x), '') IS NOT NULL
+    ) needles
+  );
+  v_total_count int;
+  v_total_pages int;
+  v_has_more boolean;
+  v_blogs jsonb;
+BEGIN
+  IF v_sort NOT IN ('newest', 'oldest', 'popular') THEN
+    RAISE EXCEPTION 'Unsupported sort "%" (allowed: newest, oldest, popular)', p_sort
+      USING ERRCODE = '22023';
+  END IF;
+
+  WITH filtered AS (
+    SELECT b.id, b.created_at, b.published_at, b.likes_count
+    FROM public.blogs b
+    WHERE b.status = 'published'
+      AND (
+        v_slugs IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM public.blog_tag_links l
+          JOIN public.blog_tags t ON t.id = l.tag_id
+          WHERE l.blog_id = b.id
+            AND (
+              lower(t.slug) = ANY(v_slugs)
+              OR lower(t.name) = ANY(v_slugs)
+            )
+        )
+      )
+  ),
+  paged AS (
+    SELECT
+      f.id,
+      row_number() OVER (
+        ORDER BY
+          CASE WHEN v_sort = 'popular' THEN f.likes_count END DESC,
+          CASE WHEN v_sort = 'oldest' THEN COALESCE(f.published_at, f.created_at) END ASC,
+          CASE WHEN v_sort IN ('newest', 'popular') THEN COALESCE(f.published_at, f.created_at) END DESC,
+          f.id DESC
+      ) AS row_num
+    FROM filtered f
+    ORDER BY
+      CASE WHEN v_sort = 'popular' THEN f.likes_count END DESC,
+      CASE WHEN v_sort = 'oldest' THEN COALESCE(f.published_at, f.created_at) END ASC,
+      CASE WHEN v_sort IN ('newest', 'popular') THEN COALESCE(f.published_at, f.created_at) END DESC,
+      f.id DESC
+    LIMIT v_limit
+    OFFSET v_offset
+  )
+  SELECT
+    (SELECT count(*)::int FROM filtered),
+    COALESCE(
+      (
+        SELECT jsonb_agg(public.blog_json_row_fragment(p.id) ORDER BY p.row_num)
+        FROM paged p
+      ),
+      '[]'::jsonb
+    )
+  INTO v_total_count, v_blogs;
+
+  v_total_pages := CASE
+    WHEN v_total_count = 0 THEN 0
+    ELSE CEIL(v_total_count::numeric / v_limit::numeric)::int
+  END;
+  v_has_more := (v_offset + v_limit) < v_total_count;
+
+  RETURN jsonb_build_object(
+    'blogs', v_blogs,
+    'totalCount', v_total_count,
+    'hasMore', v_has_more,
+    'currentPage', v_page,
+    'totalPages', v_total_pages,
+    'pagination', jsonb_build_object(
+      'page', v_page,
+      'limit', v_limit,
+      'total', v_total_count,
+      'has_more', v_has_more
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.blog_public_list_by_tags(text[], int, int, text) IS
+  'Public multi-tag blog list RPC (OR/union). Args: p_tag_slugs text[] default null (tag slugs or display names, case-insensitive; a post matches if it carries ANY of them; empty/null = no tag filter), p_page int default 1, p_limit int default 10 (clamped 1..100), p_sort text default newest in {newest,oldest,popular}. Returns the same paginated jsonb envelope as blog_public_list_published, scoped to published posts.';
+
+REVOKE ALL ON FUNCTION public.blog_public_list_by_tags(text[], int, int, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.blog_public_list_by_tags(text[], int, int, text) TO anon, authenticated;


### PR DESCRIPTION
## Summary
This PR extends the blog filtering system to support selecting multiple topics simultaneously, using OR/union semantics (a post matches if it carries *any* of the selected tags). Previously, only single-tag filtering was supported.

## Key Changes

- **New RPC function** (`blog_public_list_by_tags`): Created a PostgreSQL function that accepts an array of tag slugs/names and returns published posts matching any of them. Mirrors the pagination, sorting, and envelope of the existing `blog_public_list_published` RPC.

- **Store refactoring**: 
  - Changed `activeTag: string | null` to `activeTags: string[]` in `useBlogListingStore`
  - Renamed `handleTagChange` → `applyTagFilter` to reflect the new behavior (replaces the entire tag selection)
  - Updated `hydrateFromParams` to accept `tags?: string[]` instead of `tag?: string`

- **Service layer updates**:
  - Renamed `getBlogsByTag(tag)` → `getBlogsByTags(tags[])` in both `blogService.ts` and `dummyBlogService.ts`
  - Updated calls to use the new RPC `blog_public_list_by_tags` with `p_tag_slugs` parameter
  - Dummy service now implements OR semantics: empty tag selection returns all posts

- **URL parameter handling**:
  - Added `parseTagsParam()` helper to parse comma-separated tag values from query strings
  - Updated URL sync to prefer `tags=a,b,c` format while falling back to legacy `tag=a` for backward compatibility
  - `onTagChange` → `onTagToggle`: now toggles individual tags in/out of the active set rather than replacing

- **UI updates**:
  - Blog listing now displays multiple active tag badges with individual remove buttons
  - Added "Clear all" button when multiple tags are selected
  - Updated label from "Filtering by tag:" to "Filtering by topic(s):"
  - `TopicCloud` and `TopicBadge` components updated to work with `activeTags[]` and show active state for multiple selections
  - Sheet behavior: topic cloud now stays open when toggling tags (allows multi-select without closing)

- **Blog detail page**: Updated tag click handler to use `tags=` parameter instead of `tag=`

## Notable Implementation Details

- The effect dependency in `BlogPage` uses `activeTagsKey = activeTags.join(",")` to create a stable primitive, preventing unnecessary re-renders from fresh array references
- Empty/null tag array in the RPC returns all published posts (no tag filter), allowing the function to serve as a general list endpoint
- Tag matching is case-insensitive and supports both slug and display name matching in the RPC
- Maintains backward compatibility with existing single-tag URLs via fallback parsing