### PR TITLE
Add scheduled publishing for blog posts with auto-publish via pg_cron

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:remote:reset": "npx supabase db reset --linked 2>&1",
     "db:remote:push": "npx supabase db push --linked 2>&1",
     "db:verify:rbac-e2e": "npx supabase db reset --no-seed 2>&1 && psql \"postgresql://postgres:postgres@127.0.0.1:54322/postgres\" -v ON_ERROR_STOP=1 -f supabase/verify/verify_rbac_e2e.sql 2>&1",
+    "db:verify:scheduled-publishing": "npx supabase db reset --no-seed 2>&1 && psql \"postgresql://postgres:postgres@127.0.0.1:54322/postgres\" -v ON_ERROR_STOP=1 -f supabase/verify/verify_scheduled_publishing.sql 2>&1",
     "db:verify:tag-admin": "npx supabase db reset --no-seed 2>&1 && psql \"postgresql://postgres:postgres@127.0.0.1:54322/postgres\" -v ON_ERROR_STOP=1 -f supabase/verify/verify_tag_admin.sql 2>&1"
   },
   "dependencies": {

--- a/src/features/dashboard/blogs/AllBlogs.tsx
+++ b/src/features/dashboard/blogs/AllBlogs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { formatDistanceToNow } from "date-fns";
@@ -16,6 +16,8 @@ import {
   Loader2,
   RefreshCw,
   X,
+  CalendarClock,
+  Rocket,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -55,6 +57,15 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAllBlogsStore } from "./store";
 import { useDebouncedValue } from "@/hooks";
@@ -84,10 +95,16 @@ export function AllBlogs() {
     clearSelection,
     bulkUpdateStatus,
     bulkDelete,
+    scheduleBlog,
+    publishNow,
   } = useAllBlogsStore();
 
   const allSelected =
     blogs.length > 0 && blogs.every((b) => selectedIds.includes(b.id));
+
+  // Schedule dialog: which post, and the chosen datetime-local value.
+  const [scheduleFor, setScheduleFor] = useState<{ id: string; title: string } | null>(null);
+  const [scheduleAt, setScheduleAt] = useState("");
 
   // Debounced search — sync searchInput → filters.search
   const debouncedSearch = useDebouncedValue(searchInput, 300);
@@ -156,6 +173,8 @@ export function AllBlogs() {
     switch (status) {
       case "published":
         return "default" as const;
+      case "scheduled":
+        return "outline" as const;
       case "draft":
         return "secondary" as const;
       case "archived":
@@ -163,6 +182,47 @@ export function AllBlogs() {
       default:
         return "secondary" as const;
     }
+  }
+
+  function openSchedule(blog: { id: string; title: string }) {
+    // Default the picker to one hour out, formatted for datetime-local (local tz).
+    const oneHourOut = new Date(Date.now() + 60 * 60 * 1000);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const local = `${oneHourOut.getFullYear()}-${pad(oneHourOut.getMonth() + 1)}-${pad(
+      oneHourOut.getDate()
+    )}T${pad(oneHourOut.getHours())}:${pad(oneHourOut.getMinutes())}`;
+    setScheduleAt(local);
+    setScheduleFor(blog);
+  }
+
+  function handleConfirmSchedule() {
+    if (!scheduleFor || !scheduleAt) return;
+    const iso = new Date(scheduleAt).toISOString();
+    if (Number.isNaN(Date.parse(iso)) || new Date(iso) <= new Date()) {
+      toast.error("Pick a time in the future");
+      return;
+    }
+    const target = scheduleFor;
+    startTransition(async () => {
+      try {
+        await scheduleBlog(target.id, iso);
+        toast.success(`“${target.title}” scheduled`);
+        setScheduleFor(null);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to schedule");
+      }
+    });
+  }
+
+  function handlePublishNow(blog: { id: string; title: string }) {
+    startTransition(async () => {
+      try {
+        await publishNow(blog.id);
+        toast.success(`“${blog.title}” published`);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to publish");
+      }
+    });
   }
 
   return (
@@ -486,6 +546,26 @@ export function AllBlogs() {
                           Edit
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
+                        {blog.status === "scheduled" ? (
+                          <DropdownMenuItem
+                            onClick={() =>
+                              handlePublishNow({ id: blog.id, title: blog.title })
+                            }
+                          >
+                            <Rocket className="mr-2 h-4 w-4" />
+                            Publish now
+                          </DropdownMenuItem>
+                        ) : (
+                          <DropdownMenuItem
+                            onClick={() =>
+                              openSchedule({ id: blog.id, title: blog.title })
+                            }
+                          >
+                            <CalendarClock className="mr-2 h-4 w-4" />
+                            Schedule…
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuSeparator />
                         <AlertDialog>
                           <AlertDialogTrigger
                             nativeButton={false}
@@ -561,6 +641,46 @@ export function AllBlogs() {
           </div>
         </div>
       )}
+
+      {/* Schedule dialog */}
+      <Dialog
+        open={scheduleFor !== null}
+        onOpenChange={(open) => {
+          if (!open) setScheduleFor(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Schedule post</DialogTitle>
+            <DialogDescription>
+              Pick when “{scheduleFor?.title}” should go live. It stays hidden
+              until then, and publishes automatically — no further action needed.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="publish-at">Publish at</Label>
+            <Input
+              id="publish-at"
+              type="datetime-local"
+              value={scheduleAt}
+              onChange={(e) => setScheduleAt(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Uses your local time zone. Publishing runs on a one-minute cron, so
+              it may go live up to a minute after this time.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setScheduleFor(null)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmSchedule} disabled={isPending || !scheduleAt}>
+              {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Schedule
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/features/dashboard/blogs/EditBlog.tsx
+++ b/src/features/dashboard/blogs/EditBlog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Save,
   Rocket,
+  CalendarClock,
   Loader2,
   ArrowLeft,
   X,
@@ -51,6 +52,17 @@ interface EditBlogProps {
   blogId: string;
 }
 
+/** Format an ISO datetime to a `datetime-local` input value in local time. */
+function toDateTimeLocal(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours()
+  )}:${pad(d.getMinutes())}`;
+}
+
 export function EditBlog({ blogId }: EditBlogProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -79,10 +91,12 @@ export function EditBlog({ blogId }: EditBlogProps) {
       metaTitle: "",
       metaDescription: "",
       status: "draft",
+      publishAt: "",
     },
   });
 
   const status = watch("status");
+  const publishAt = watch("publishAt") ?? "";
   const content = watch("content");
   const categoryId = watch("categoryId") ?? "";
   const imageUrl = watch("imageUrl") ?? "";
@@ -134,7 +148,9 @@ export function EditBlog({ blogId }: EditBlogProps) {
           imageUrl: blog.imageUrl || "",
           metaTitle: blog.metaTitle || "",
           metaDescription: blog.metaDescription || "",
-          status: (blog.status as "published" | "draft") || "draft",
+          status:
+            (blog.status as "published" | "draft" | "scheduled") || "draft",
+          publishAt: toDateTimeLocal(blog.publishAt),
         };
         const nextSourceFingerprint = JSON.stringify(baselineValues);
 
@@ -172,10 +188,17 @@ export function EditBlog({ blogId }: EditBlogProps) {
         if (data.metaTitle) formData.append("metaTitle", data.metaTitle);
         if (data.metaDescription) formData.append("metaDescription", data.metaDescription);
         formData.append("status", data.status);
+        if (data.status === "scheduled" && data.publishAt) {
+          formData.append("publishAt", new Date(data.publishAt).toISOString());
+        }
 
         await dashboardBlogService.updateBlog(blogId, formData);
         clearDraft();
-        toast.success("Blog updated successfully!");
+        toast.success(
+          data.status === "scheduled"
+            ? "Blog scheduled."
+            : "Blog updated successfully!"
+        );
         router.push("/dashboard/blogs");
       } catch (error) {
         toast.error(
@@ -192,6 +215,20 @@ export function EditBlog({ blogId }: EditBlogProps) {
 
   function handlePublish() {
     setValue("status", "published");
+    handleSubmit(onSubmit)();
+  }
+
+  function handleSchedule() {
+    const when = publishAt;
+    if (!when) {
+      toast.error("Pick a date & time to schedule");
+      return;
+    }
+    if (new Date(when) <= new Date()) {
+      toast.error("Pick a time in the future");
+      return;
+    }
+    setValue("status", "scheduled");
     handleSubmit(onSubmit)();
   }
 
@@ -251,6 +288,16 @@ export function EditBlog({ blogId }: EditBlogProps) {
             <Save className="mr-2 h-4 w-4" />
             Save Draft
           </Button>
+          {publishAt && (
+            <Button
+              variant="secondary"
+              onClick={handleSchedule}
+              disabled={isPending}
+            >
+              <CalendarClock className="mr-2 h-4 w-4" />
+              Schedule
+            </Button>
+          )}
           <Button onClick={handlePublish} disabled={isPending}>
             {isPending ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -339,8 +386,24 @@ export function EditBlog({ blogId }: EditBlogProps) {
               <p className="text-xs text-muted-foreground">
                 {status === "published"
                   ? "This post is live."
-                  : "This post is a draft."}
+                  : status === "scheduled"
+                    ? "This post will publish automatically at the time below."
+                    : "This post is a draft."}
               </p>
+
+              <div className="space-y-2 border-t border-border pt-4">
+                <Label htmlFor="publish-at">Schedule for later</Label>
+                <Input
+                  id="publish-at"
+                  type="datetime-local"
+                  {...register("publishAt")}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Set a future time and press <strong>Schedule</strong> — it
+                  publishes automatically then (checked every minute), no further
+                  action needed.
+                </p>
+              </div>
             </CardContent>
           </Card>
 

--- a/src/features/dashboard/blogs/NewBlog.tsx
+++ b/src/features/dashboard/blogs/NewBlog.tsx
@@ -13,6 +13,7 @@ import {
   ArrowLeft,
   X,
   Plus,
+  CalendarClock,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -81,10 +82,12 @@ export function NewBlog() {
       metaTitle: "",
       metaDescription: "",
       status: "draft",
+      publishAt: "",
     },
   });
 
   const status = watch("status");
+  const publishAt = watch("publishAt") ?? "";
   const content = watch("content");
   const categoryId = watch("categoryId") ?? "";
   const imageUrl = watch("imageUrl") ?? "";
@@ -117,13 +120,18 @@ export function NewBlog() {
         if (data.metaTitle) formData.append("metaTitle", data.metaTitle);
         if (data.metaDescription) formData.append("metaDescription", data.metaDescription);
         formData.append("status", data.status);
+        if (data.status === "scheduled" && data.publishAt) {
+          formData.append("publishAt", new Date(data.publishAt).toISOString());
+        }
 
         await dashboardBlogService.createBlog(formData);
         clearDraft();
         toast.success(
           data.status === "published"
             ? "Blog published successfully!"
-            : "Blog saved as draft."
+            : data.status === "scheduled"
+              ? "Blog scheduled."
+              : "Blog saved as draft."
         );
         router.push("/dashboard/blogs");
       } catch (error) {
@@ -141,6 +149,20 @@ export function NewBlog() {
 
   function handlePublish() {
     setValue("status", "published");
+    handleSubmit(onSubmit)();
+  }
+
+  function handleSchedule() {
+    const when = publishAt;
+    if (!when) {
+      toast.error("Pick a date & time to schedule");
+      return;
+    }
+    if (new Date(when) <= new Date()) {
+      toast.error("Pick a time in the future");
+      return;
+    }
+    setValue("status", "scheduled");
     handleSubmit(onSubmit)();
   }
 
@@ -183,6 +205,16 @@ export function NewBlog() {
             <Save className="mr-2 h-4 w-4" />
             Save Draft
           </Button>
+          {publishAt && (
+            <Button
+              variant="secondary"
+              onClick={handleSchedule}
+              disabled={isPending}
+            >
+              <CalendarClock className="mr-2 h-4 w-4" />
+              Schedule
+            </Button>
+          )}
           <Button onClick={handlePublish} disabled={isPending}>
             {isPending ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -279,8 +311,24 @@ export function NewBlog() {
               <p className="text-xs text-muted-foreground">
                 {status === "published"
                   ? "This post will be visible to readers."
-                  : "This post will be saved as a draft."}
+                  : status === "scheduled"
+                    ? "This post will publish automatically at the time below."
+                    : "This post will be saved as a draft."}
               </p>
+
+              <div className="space-y-2 border-t border-border pt-4">
+                <Label htmlFor="publish-at">Schedule for later</Label>
+                <Input
+                  id="publish-at"
+                  type="datetime-local"
+                  {...register("publishAt")}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Set a future time and press <strong>Schedule</strong> — it
+                  publishes automatically then (checked every minute), no further
+                  action needed.
+                </p>
+              </div>
             </CardContent>
           </Card>
 

--- a/src/features/dashboard/blogs/hooks/useBlogDraftPersistence.ts
+++ b/src/features/dashboard/blogs/hooks/useBlogDraftPersistence.ts
@@ -21,6 +21,7 @@ const EMPTY_VALUES: BlogDraftValues = {
   metaTitle: "",
   metaDescription: "",
   status: "draft",
+  publishAt: "",
 };
 
 type DraftMode = "new" | "edit";
@@ -58,6 +59,7 @@ function normalizeValues(
     metaTitle: values?.metaTitle ?? EMPTY_VALUES.metaTitle,
     metaDescription: values?.metaDescription ?? EMPTY_VALUES.metaDescription,
     status: values?.status ?? EMPTY_VALUES.status,
+    publishAt: values?.publishAt ?? EMPTY_VALUES.publishAt,
   };
 }
 

--- a/src/features/dashboard/blogs/store.ts
+++ b/src/features/dashboard/blogs/store.ts
@@ -48,6 +48,10 @@ interface AllBlogsState {
   clearFilters: () => void;
   loadBlogs: () => Promise<void>;
   deleteBlog: (blogId: string) => Promise<void>;
+  /** Schedule a post for future auto-publication (pg_cron flips it when due). */
+  scheduleBlog: (blogId: string, publishAtIso: string) => Promise<void>;
+  /** Publish a scheduled (or draft) post immediately. */
+  publishNow: (blogId: string) => Promise<void>;
 
   // Bulk selection
   toggleSelected: (blogId: string) => void;
@@ -109,6 +113,16 @@ export const useAllBlogsStore = create<AllBlogsState>((set, get) => ({
   deleteBlog: async (blogId) => {
     await dashboardBlogService.deleteBlog(blogId);
     // Reload after deletion
+    await get().loadBlogs();
+  },
+
+  scheduleBlog: async (blogId, publishAtIso) => {
+    await dashboardBlogService.scheduleBlog(blogId, publishAtIso);
+    await get().loadBlogs();
+  },
+
+  publishNow: async (blogId) => {
+    await dashboardBlogService.updateBlogStatus(blogId, "published");
     await get().loadBlogs();
   },
 

--- a/src/features/dashboard/blogs/store/blogDraftStore.ts
+++ b/src/features/dashboard/blogs/store/blogDraftStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-export type BlogDraftStatus = "draft" | "published";
+export type BlogDraftStatus = "draft" | "published" | "scheduled";
 
 export interface BlogDraftValues {
   title: string;
@@ -14,6 +14,7 @@ export interface BlogDraftValues {
   metaTitle: string;
   metaDescription: string;
   status: BlogDraftStatus;
+  publishAt: string;
 }
 
 export interface BlogDraftEntry {

--- a/src/features/dashboard/blogs/validations/editBlogs.validations.ts
+++ b/src/features/dashboard/blogs/validations/editBlogs.validations.ts
@@ -9,6 +9,8 @@ export const blogFormSchema = z.object({
     imageUrl: z.string().optional(),
     metaTitle: z.string().optional(),
     metaDescription: z.string().optional(),
-    status: z.enum(["published", "draft"]),
+    status: z.enum(["published", "draft", "scheduled"]),
+    /** datetime-local value; required by the UI when status = 'scheduled'. */
+    publishAt: z.string().optional(),
   });
   

--- a/src/features/dashboard/services/dashboardBlogService.ts
+++ b/src/features/dashboard/services/dashboardBlogService.ts
@@ -198,6 +198,12 @@ function buildPayloadFromFormData(formData: FormData): BlogAdminRpcPayload {
     payload.tag_names = tagNames;
   }
 
+  // Only meaningful when status is 'scheduled'; the RPC validates it.
+  const publishAt = String(formData.get("publishAt") ?? "").trim();
+  if (publishAt) {
+    payload.publish_at = publishAt;
+  }
+
   return payload;
 }
 

--- a/src/features/dashboard/services/dashboardBlogService.ts
+++ b/src/features/dashboard/services/dashboardBlogService.ts
@@ -268,7 +268,7 @@ export async function updateBlogStatus(blogId: string, status: BlogStatus): Prom
 
 export async function scheduleBlog(blogId: string, publishAtIso: string): Promise<void> {
   const supabase = createClient();
-  const { error } = await supabase.rpc("blog_admin_schedule", {
+  const { error } = await supabase.rpc("blog_schedule_post", {
     p_blog_id: blogId,
     p_publish_at: publishAtIso,
   });

--- a/src/features/dashboard/services/dashboardBlogService.ts
+++ b/src/features/dashboard/services/dashboardBlogService.ts
@@ -266,6 +266,18 @@ export async function updateBlogStatus(blogId: string, status: BlogStatus): Prom
   }
 }
 
+export async function scheduleBlog(blogId: string, publishAtIso: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("blog_admin_schedule", {
+    p_blog_id: blogId,
+    p_publish_at: publishAtIso,
+  });
+
+  if (error) {
+    throw new Error(error.message || "Failed to schedule blog.");
+  }
+}
+
 export async function deleteBlog(blogId: string): Promise<void> {
   const supabase = createClient();
   const { data, error } = await supabase.rpc("blog_admin_delete", {
@@ -372,6 +384,7 @@ export const dashboardBlogService = {
   createBlog,
   updateBlog,
   updateBlogStatus,
+  scheduleBlog,
   deleteBlog,
   getDashboardStats,
   getDashboardRecentActivity,

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -6,7 +6,7 @@ import type { BlogPost, BlogCategory, IsoDateString } from "./blog";
 
 // ─── Admin Filters & Pagination ───
 
-export type BlogStatus = "published" | "draft" | "archived";
+export type BlogStatus = "published" | "draft" | "archived" | "scheduled";
 export type BlogAdminRpcSortBy =
   | "created_at"
   | "updated_at"

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -103,6 +103,8 @@ export interface BlogAdminRpcPayload {
   meta_title?: string | null;
   meta_description?: string | null;
   status?: BlogStatus;
+  /** ISO datetime; required by the RPC when status = 'scheduled'. */
+  publish_at?: string | null;
   author_image?: string | null;
   is_new?: boolean;
   is_featured?: boolean;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -55,7 +55,9 @@ export interface BlogPost {
   metaDescription?: string;
   likes?: number;
   comments?: BlogComment[];
-  status?: "published" | "draft" | "archived";
+  status?: "published" | "draft" | "archived" | "scheduled";
+  /** For scheduled posts: the UTC time the cron job will publish it. */
+  publishAt?: IsoDateString;
   viewsCount?: number;
   likesCount?: number;
 }

--- a/supabase/migrations/20260718000100_blog_status_scheduled_enum.sql
+++ b/supabase/migrations/20260718000100_blog_status_scheduled_enum.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration: 20260718000100_blog_status_scheduled_enum.sql
+-- Domain: BLOGS
+-- Type: Enum extension
+-- Purpose: Add a 'scheduled' lifecycle status for future-dated auto-publishing.
+--
+-- NOTE: this lives in its own migration on purpose — PostgreSQL forbids USING a
+-- newly added enum value in the same transaction that adds it. The follow-up
+-- migration (…000200) references 'scheduled' and therefore must run afterwards.
+-- =============================================================================
+
+ALTER TYPE public.blog_status ADD VALUE IF NOT EXISTS 'scheduled';
+
+COMMENT ON TYPE public.blog_status IS
+  'Blog lifecycle status (draft, scheduled, published, archived). "scheduled" posts are not public until blog_publish_due() flips them to "published" at their publish_at time.';

--- a/supabase/migrations/20260718000200_blog_scheduled_publishing.sql
+++ b/supabase/migrations/20260718000200_blog_scheduled_publishing.sql
@@ -114,21 +114,40 @@ REVOKE ALL ON FUNCTION public.blog_publish_due() FROM PUBLIC, anon, authenticate
 GRANT EXECUTE ON FUNCTION public.blog_publish_due() TO postgres, service_role;
 
 -- ── pg_cron: run the flip every minute (no user intervention) ────────────────
+-- Idempotent + non-fatal. On managed Postgres (e.g. Supabase) pg_cron is often
+-- already enabled, and re-issuing CREATE EXTENSION against the existing one
+-- fails with 2BP01 (dependent privileges). So only create it when it is truly
+-- absent, and never let the cron wiring abort the migration — the RPCs above
+-- are the important part; scheduling can also be driven by an Edge Function /
+-- external cron if pg_cron is unavailable.
 
-CREATE EXTENSION IF NOT EXISTS pg_cron;
-
--- Re-schedule idempotently so re-running the migration doesn't stack jobs.
 DO $$
 BEGIN
-  PERFORM cron.unschedule(jobid)
-  FROM cron.job
-  WHERE jobname = 'blog-publish-due';
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    BEGIN
+      EXECUTE 'CREATE EXTENSION pg_cron';
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Could not enable pg_cron (%). Enable it once, then re-run — or schedule blog_publish_due() via an Edge Function / external cron.', SQLERRM;
+    END;
+  END IF;
+END $$;
 
-  PERFORM cron.schedule(
-    'blog-publish-due',
-    '* * * * *',
-    'SELECT public.blog_publish_due();'
-  );
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- Re-schedule idempotently so re-running the migration doesn't stack jobs.
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'blog-publish-due';
+
+    PERFORM cron.schedule(
+      'blog-publish-due',
+      '* * * * *',
+      'SELECT public.blog_publish_due();'
+    );
+  ELSE
+    RAISE NOTICE 'pg_cron unavailable; blog_publish_due() was not scheduled. Drive it via an Edge Function / external cron, or enable pg_cron and re-run.';
+  END IF;
 END $$;
 
 -- =============================================================================

--- a/supabase/migrations/20260718000200_blog_scheduled_publishing.sql
+++ b/supabase/migrations/20260718000200_blog_scheduled_publishing.sql
@@ -2,7 +2,8 @@
 -- Migration: 20260718000200_blog_scheduled_publishing.sql
 -- Domain: BLOGS
 -- Type: Column + RPCs + pg_cron schedule
--- Purpose: Future-dated auto-publishing. Admins schedule a post; a pg_cron job
+-- Purpose: Future-dated auto-publishing. A post's author (or an admin)
+--          schedules it; a pg_cron job
 --          flips due 'scheduled' posts to 'published' every minute — no user
 --          intervention. Public read RPCs need no change: a scheduled post is
 --          simply not 'published' until the job flips it.
@@ -23,9 +24,9 @@ CREATE INDEX IF NOT EXISTS blogs_scheduled_publish_at_idx
   ON public.blogs (publish_at)
   WHERE status = 'scheduled';
 
--- ── Admin: schedule a post for future publication ────────────────────────────
+-- ── Schedule a post for future publication (author or admin) ─────────────────
 
-CREATE OR REPLACE FUNCTION public.blog_admin_schedule(
+CREATE OR REPLACE FUNCTION public.blog_schedule_post(
   p_blog_id uuid,
   p_publish_at timestamptz
 )
@@ -71,8 +72,8 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.blog_admin_schedule(uuid, timestamptz) IS
-  'Admin blog write RPC. Args: p_blog_id uuid, p_publish_at timestamptz (must be future). Enforces RBAC (row author or admin). Sets status=scheduled + publish_at and clears published_at. Returns {"ok":true,"id","status":"scheduled","publishAt"}. A pg_cron job publishes it at publish_at.';
+COMMENT ON FUNCTION public.blog_schedule_post(uuid, timestamptz) IS
+  'Blog scheduling write RPC (not admin-only). Args: p_blog_id uuid, p_publish_at timestamptz (must be future). Callable by any authenticated user; RBAC is enforced in-function via blog_assert_blog_write_access (row author or admin). Sets status=scheduled + publish_at and clears published_at. Returns {"ok":true,"id","status":"scheduled","publishAt"}. A pg_cron job publishes it at publish_at.';
 
 -- ── System: publish all due scheduled posts (the cron target) ────────────────
 
@@ -105,8 +106,8 @@ COMMENT ON FUNCTION public.blog_publish_due() IS
 
 -- ── Grants ───────────────────────────────────────────────────────────────────
 
-REVOKE ALL ON FUNCTION public.blog_admin_schedule(uuid, timestamptz) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.blog_admin_schedule(uuid, timestamptz) TO authenticated;
+REVOKE ALL ON FUNCTION public.blog_schedule_post(uuid, timestamptz) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.blog_schedule_post(uuid, timestamptz) TO authenticated;
 
 -- System-only: pg_cron runs as postgres; an Edge Function would use service_role.
 REVOKE ALL ON FUNCTION public.blog_publish_due() FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260718000200_blog_scheduled_publishing.sql
+++ b/supabase/migrations/20260718000200_blog_scheduled_publishing.sql
@@ -1,0 +1,135 @@
+-- =============================================================================
+-- Migration: 20260718000200_blog_scheduled_publishing.sql
+-- Domain: BLOGS
+-- Type: Column + RPCs + pg_cron schedule
+-- Purpose: Future-dated auto-publishing. Admins schedule a post; a pg_cron job
+--          flips due 'scheduled' posts to 'published' every minute — no user
+--          intervention. Public read RPCs need no change: a scheduled post is
+--          simply not 'published' until the job flips it.
+-- Dependencies: 20260718000100 (blog_status 'scheduled'), blogs,
+--               blog_assert_blog_write_access
+-- =============================================================================
+
+-- ── Column: when a scheduled post should go live ─────────────────────────────
+
+ALTER TABLE public.blogs
+  ADD COLUMN IF NOT EXISTS publish_at timestamptz;
+
+COMMENT ON COLUMN public.blogs.publish_at IS
+  'For status = scheduled: the UTC time at which blog_publish_due() should publish this post. NULL for non-scheduled posts.';
+
+-- Supports the due-scan; partial so it only indexes rows the job cares about.
+CREATE INDEX IF NOT EXISTS blogs_scheduled_publish_at_idx
+  ON public.blogs (publish_at)
+  WHERE status = 'scheduled';
+
+-- ── Admin: schedule a post for future publication ────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.blog_admin_schedule(
+  p_blog_id uuid,
+  p_publish_at timestamptz
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing public.blogs%ROWTYPE;
+BEGIN
+  IF p_blog_id IS NULL THEN
+    RAISE EXCEPTION 'Blog id is required' USING ERRCODE = '23514';
+  END IF;
+  IF p_publish_at IS NULL THEN
+    RAISE EXCEPTION 'A publish time is required' USING ERRCODE = '23514';
+  END IF;
+  IF p_publish_at <= timezone('utc', now()) THEN
+    RAISE EXCEPTION 'Publish time must be in the future' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_existing FROM public.blogs b WHERE b.id = p_blog_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Blog "%" not found', p_blog_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Same RBAC as blog_admin_update: row author or blog admin only.
+  PERFORM public.blog_assert_blog_write_access(v_existing.author_id);
+
+  UPDATE public.blogs b
+  SET status = 'scheduled',
+      publish_at = p_publish_at,
+      published_at = NULL
+  WHERE b.id = p_blog_id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'id', p_blog_id,
+    'status', 'scheduled',
+    'publishAt', p_publish_at
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.blog_admin_schedule(uuid, timestamptz) IS
+  'Admin blog write RPC. Args: p_blog_id uuid, p_publish_at timestamptz (must be future). Enforces RBAC (row author or admin). Sets status=scheduled + publish_at and clears published_at. Returns {"ok":true,"id","status":"scheduled","publishAt"}. A pg_cron job publishes it at publish_at.';
+
+-- ── System: publish all due scheduled posts (the cron target) ────────────────
+
+CREATE OR REPLACE FUNCTION public.blog_publish_due()
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  WITH due AS (
+    UPDATE public.blogs
+    SET status = 'published',
+        published_at = COALESCE(published_at, publish_at, timezone('utc', now()))
+    WHERE status = 'scheduled'
+      AND publish_at IS NOT NULL
+      AND publish_at <= timezone('utc', now())
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_count FROM due;
+  RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.blog_publish_due() IS
+  'System RPC. Publishes every scheduled post whose publish_at has passed (status scheduled -> published, sets published_at from publish_at). Returns the number published. Intended to be called on a schedule by pg_cron; not exposed to anon/authenticated.';
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+
+REVOKE ALL ON FUNCTION public.blog_admin_schedule(uuid, timestamptz) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.blog_admin_schedule(uuid, timestamptz) TO authenticated;
+
+-- System-only: pg_cron runs as postgres; an Edge Function would use service_role.
+REVOKE ALL ON FUNCTION public.blog_publish_due() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.blog_publish_due() TO postgres, service_role;
+
+-- ── pg_cron: run the flip every minute (no user intervention) ────────────────
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Re-schedule idempotently so re-running the migration doesn't stack jobs.
+DO $$
+BEGIN
+  PERFORM cron.unschedule(jobid)
+  FROM cron.job
+  WHERE jobname = 'blog-publish-due';
+
+  PERFORM cron.schedule(
+    'blog-publish-due',
+    '* * * * *',
+    'SELECT public.blog_publish_due();'
+  );
+END $$;
+
+-- =============================================================================
+-- Migration Complete
+-- =============================================================================

--- a/supabase/migrations/20260718000300_blog_admin_scheduled_write.sql
+++ b/supabase/migrations/20260718000300_blog_admin_scheduled_write.sql
@@ -1,0 +1,387 @@
+-- =============================================================================
+-- Migration: 20260718000300_blog_admin_scheduled_write.sql
+-- Domain: BLOGS
+-- Type: RPC redefinition
+-- Purpose: Let authors set a schedule while authoring — blog_admin_create and
+--          blog_admin_update now read a `publish_at` payload key and honor
+--          status = 'scheduled' (validated to be in the future). Redefines the
+--          two write RPCs from 20260101000404 verbatim + the publish_at handling.
+-- Dependencies: 20260718000100 ('scheduled' enum), 20260718000200 (publish_at
+--               column), blog_resolve_slug, blog_json_row_fragment,
+--               blog_admin_sync_tag_links, blog_assert_authenticated_user,
+--               blog_assert_blog_write_access
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.blog_admin_create(
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_actor_id uuid;
+  v_blog_id uuid;
+  v_title text;
+  v_slug text;
+  v_status public.blog_status;
+  v_publish_at timestamptz;
+  v_category_id uuid;
+  v_category_name text;
+  v_tag_names text[] := ARRAY[]::text[];
+  v_author_name text;
+  v_author_image text;
+BEGIN
+  v_actor_id := public.blog_assert_authenticated_user();
+
+  IF p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+    RAISE EXCEPTION 'Create payload must be a json object'
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_title := NULLIF(trim(p_payload ->> 'title'), '');
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'Create payload field "title" is required'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NOT (p_payload ? 'content') THEN
+    RAISE EXCEPTION 'Create payload field "content" is required'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF p_payload ? 'category_id' THEN
+    v_category_id := NULLIF(trim(p_payload ->> 'category_id'), '')::uuid;
+  ELSE
+    v_category_id := NULL;
+  END IF;
+
+  IF v_category_id IS NOT NULL THEN
+    SELECT c.name
+    INTO v_category_name
+    FROM public.blog_categories c
+    WHERE c.id = v_category_id;
+
+    IF v_category_name IS NULL THEN
+      RAISE EXCEPTION 'Category "%" was not found', v_category_id
+        USING ERRCODE = '23503';
+    END IF;
+  ELSE
+    v_category_name := NULL;
+  END IF;
+
+  v_slug := public.blog_resolve_slug(
+    p_title => v_title,
+    p_slug => NULLIF(p_payload ->> 'slug', '')
+  );
+
+  v_status := COALESCE(NULLIF(trim(p_payload ->> 'status'), ''), 'draft')::public.blog_status;
+
+  -- Scheduling: a future publish_at is required when status = scheduled.
+  IF v_status = 'scheduled' THEN
+    v_publish_at := NULLIF(trim(p_payload ->> 'publish_at'), '')::timestamptz;
+    IF v_publish_at IS NULL THEN
+      RAISE EXCEPTION 'A future publish_at is required to schedule a post'
+        USING ERRCODE = '23514';
+    END IF;
+    IF v_publish_at <= timezone('utc', now()) THEN
+      RAISE EXCEPTION 'publish_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+  ELSE
+    v_publish_at := NULL;
+  END IF;
+
+  SELECT p.username, p.avatar_url
+  INTO v_author_name, v_author_image
+  FROM public.user_profiles p
+  WHERE p.id = v_actor_id;
+
+  IF v_author_name IS NULL THEN
+    RAISE EXCEPTION 'Author profile not found for current user'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  INSERT INTO public.blogs (
+    slug,
+    title,
+    description,
+    content,
+    author_id,
+    author,
+    author_image,
+    category_id,
+    category,
+    image_url,
+    read_time,
+    meta_title,
+    meta_description,
+    status,
+    published_at,
+    publish_at,
+    is_new,
+    is_featured
+  )
+  VALUES (
+    v_slug,
+    v_title,
+    COALESCE(p_payload ->> 'description', ''),
+    COALESCE(p_payload ->> 'content', ''),
+    v_actor_id,
+    v_author_name,
+    COALESCE(NULLIF(p_payload ->> 'author_image', ''), v_author_image),
+    v_category_id,
+    v_category_name,
+    NULLIF(p_payload ->> 'image_url', ''),
+    COALESCE(NULLIF(trim(p_payload ->> 'read_time'), ''), '0')::integer,
+    NULLIF(p_payload ->> 'meta_title', ''),
+    NULLIF(p_payload ->> 'meta_description', ''),
+    v_status,
+    CASE WHEN v_status = 'published' THEN timezone('utc', now()) ELSE NULL END,
+    v_publish_at,
+    COALESCE((p_payload ->> 'is_new')::boolean, false),
+    COALESCE((p_payload ->> 'is_featured')::boolean, false)
+  )
+  RETURNING id INTO v_blog_id;
+
+  IF p_payload ? 'tag_names' THEN
+    IF p_payload -> 'tag_names' IS NULL OR jsonb_typeof(p_payload -> 'tag_names') = 'null' THEN
+      v_tag_names := ARRAY[]::text[];
+    ELSIF jsonb_typeof(p_payload -> 'tag_names') <> 'array' THEN
+      RAISE EXCEPTION 'Create payload field "tag_names" must be a text array'
+        USING ERRCODE = '22023';
+    ELSE
+      SELECT COALESCE(array_agg(value), ARRAY[]::text[])
+      INTO v_tag_names
+      FROM jsonb_array_elements_text(p_payload -> 'tag_names') AS t(value);
+    END IF;
+
+    PERFORM public.blog_admin_sync_tag_links(v_blog_id, v_tag_names);
+  END IF;
+
+  RETURN public.blog_json_row_fragment(v_blog_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.blog_admin_create(jsonb) IS
+  'Admin blog write RPC. Args: p_payload jsonb with snake_case keys {title(required), content(required), description?, slug?, category_id?, image_url?, read_time?, meta_title?, meta_description?, status?, publish_at? (required + future when status=scheduled), is_new?, is_featured?, tag_names?}. Requires authenticated session. Creates one blog row with author_id/auth.uid(), applies RBAC via blogs RLS, optionally replaces tag links when tag_names is provided, and returns one blog_row_json.';
+
+CREATE OR REPLACE FUNCTION public.blog_admin_update(
+  p_blog_id uuid,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing public.blogs%ROWTYPE;
+  v_title text;
+  v_slug text;
+  v_content text;
+  v_status public.blog_status;
+  v_category_id uuid;
+  v_category_name text;
+  v_published_at timestamptz;
+  v_publish_at timestamptz;
+  v_tag_names text[] := ARRAY[]::text[];
+BEGIN
+  IF p_blog_id IS NULL THEN
+    RAISE EXCEPTION 'Blog id is required'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+    RAISE EXCEPTION 'Update payload must be a json object'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_existing
+  FROM public.blogs b
+  WHERE b.id = p_blog_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Blog "%" not found', p_blog_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM public.blog_assert_blog_write_access(v_existing.author_id);
+
+  v_title := CASE
+    WHEN p_payload ? 'title' THEN NULLIF(trim(p_payload ->> 'title'), '')
+    ELSE v_existing.title
+  END;
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'Update payload field "title" cannot be blank'
+      USING ERRCODE = '23514';
+  END IF;
+
+  v_slug := CASE
+    WHEN p_payload ? 'slug' THEN public.blog_resolve_slug(v_title, NULLIF(p_payload ->> 'slug', ''))
+    ELSE v_existing.slug
+  END;
+
+  v_content := CASE
+    WHEN p_payload ? 'content' THEN COALESCE(p_payload ->> 'content', '')
+    ELSE v_existing.content
+  END;
+
+  v_category_id := CASE
+    WHEN p_payload ? 'category_id' THEN NULLIF(trim(p_payload ->> 'category_id'), '')::uuid
+    ELSE v_existing.category_id
+  END;
+
+  IF v_category_id IS NOT NULL THEN
+    SELECT c.name
+    INTO v_category_name
+    FROM public.blog_categories c
+    WHERE c.id = v_category_id;
+
+    IF v_category_name IS NULL THEN
+      RAISE EXCEPTION 'Category "%" was not found', v_category_id
+        USING ERRCODE = '23503';
+    END IF;
+  ELSE
+    v_category_name := NULL;
+  END IF;
+
+  v_status := CASE
+    WHEN p_payload ? 'status' THEN COALESCE(NULLIF(trim(p_payload ->> 'status'), ''), v_existing.status::text)::public.blog_status
+    ELSE v_existing.status
+  END;
+
+  v_published_at := CASE
+    WHEN v_status = 'published' THEN COALESCE(v_existing.published_at, timezone('utc', now()))
+    ELSE NULL
+  END;
+
+  -- Scheduling: keep/require a future publish_at while scheduled; clear it
+  -- whenever the post leaves the scheduled state.
+  IF v_status = 'scheduled' THEN
+    v_publish_at := CASE
+      WHEN p_payload ? 'publish_at' THEN NULLIF(trim(p_payload ->> 'publish_at'), '')::timestamptz
+      ELSE v_existing.publish_at
+    END;
+    IF v_publish_at IS NULL THEN
+      RAISE EXCEPTION 'A future publish_at is required to schedule a post'
+        USING ERRCODE = '23514';
+    END IF;
+    IF (p_payload ? 'publish_at') AND v_publish_at <= timezone('utc', now()) THEN
+      RAISE EXCEPTION 'publish_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+  ELSE
+    v_publish_at := NULL;
+  END IF;
+
+  UPDATE public.blogs b
+  SET slug = v_slug,
+      title = v_title,
+      description = CASE
+        WHEN p_payload ? 'description' THEN COALESCE(p_payload ->> 'description', '')
+        ELSE b.description
+      END,
+      content = v_content,
+      author_image = CASE
+        WHEN p_payload ? 'author_image' THEN NULLIF(p_payload ->> 'author_image', '')
+        ELSE b.author_image
+      END,
+      category_id = v_category_id,
+      category = v_category_name,
+      image_url = CASE
+        WHEN p_payload ? 'image_url' THEN NULLIF(p_payload ->> 'image_url', '')
+        ELSE b.image_url
+      END,
+      read_time = CASE
+        WHEN p_payload ? 'read_time' THEN COALESCE(NULLIF(trim(p_payload ->> 'read_time'), ''), '0')::integer
+        ELSE b.read_time
+      END,
+      meta_title = CASE
+        WHEN p_payload ? 'meta_title' THEN NULLIF(p_payload ->> 'meta_title', '')
+        ELSE b.meta_title
+      END,
+      meta_description = CASE
+        WHEN p_payload ? 'meta_description' THEN NULLIF(p_payload ->> 'meta_description', '')
+        ELSE b.meta_description
+      END,
+      status = v_status,
+      published_at = v_published_at,
+      publish_at = v_publish_at,
+      is_new = CASE
+        WHEN p_payload ? 'is_new' THEN COALESCE((p_payload ->> 'is_new')::boolean, false)
+        ELSE b.is_new
+      END,
+      is_featured = CASE
+        WHEN p_payload ? 'is_featured' THEN COALESCE((p_payload ->> 'is_featured')::boolean, false)
+        ELSE b.is_featured
+      END
+  WHERE b.id = p_blog_id;
+
+  IF p_payload ? 'tag_names' THEN
+    IF p_payload -> 'tag_names' IS NULL OR jsonb_typeof(p_payload -> 'tag_names') = 'null' THEN
+      v_tag_names := ARRAY[]::text[];
+    ELSIF jsonb_typeof(p_payload -> 'tag_names') <> 'array' THEN
+      RAISE EXCEPTION 'Update payload field "tag_names" must be a text array'
+        USING ERRCODE = '22023';
+    ELSE
+      SELECT COALESCE(array_agg(value), ARRAY[]::text[])
+      INTO v_tag_names
+      FROM jsonb_array_elements_text(p_payload -> 'tag_names') AS t(value);
+    END IF;
+
+    PERFORM public.blog_admin_sync_tag_links(p_blog_id, v_tag_names);
+  END IF;
+
+  RETURN public.blog_json_row_fragment(p_blog_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.blog_admin_update(uuid, jsonb) IS
+  'Admin blog write RPC. Args: p_blog_id uuid, p_payload jsonb partial patch using snake_case keys from blog_admin_create payload (incl. publish_at when status=scheduled). Requires authenticated session. Enforces RBAC (row author or admin), updates only provided fields, clears publish_at when the post leaves the scheduled state, replaces tag links only when tag_names key is present (empty array clears links), and returns one blog_row_json.';
+
+-- Expose publishAt on the shared row fragment so the editor can prefill a
+-- scheduled post's time. Null for every non-scheduled post (harmless on public
+-- rows, which are only ever 'published' and therefore have publish_at = null).
+CREATE OR REPLACE FUNCTION public.blog_json_row_fragment(p_blog_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    '_id', b.id,
+    'id', b.id,
+    'slug', b.slug,
+    'title', b.title,
+    'description', COALESCE(b.description, ''),
+    'content', b.content,
+    'author', public.blog_json_author_fragment(b.author_id, b.author),
+    'authorImage', COALESCE(b.author_image, p.avatar_url),
+    'createdAt', b.created_at,
+    'updatedAt', b.updated_at,
+    'imageUrl', b.image_url,
+    'category', public.blog_json_category_fragment(b.category_id),
+    'tags', public.blog_json_tags_fragment(b.id),
+    'readTime', format('%s min read', b.read_time),
+    'isNew', b.is_new,
+    'isFeatured', b.is_featured,
+    'metaTitle', b.meta_title,
+    'metaDescription', b.meta_description,
+    'likes', b.likes_count,
+    'status', b.status,
+    'publishAt', b.publish_at,
+    'viewsCount', b.views_count,
+    'likesCount', b.likes_count
+  )
+  FROM public.blogs b
+  LEFT JOIN public.user_profiles p ON p.id = b.author_id
+  WHERE b.id = p_blog_id;
+$$;
+
+-- =============================================================================
+-- Migration Complete
+-- =============================================================================

--- a/supabase/verify/verify_scheduled_publishing.sql
+++ b/supabase/verify/verify_scheduled_publishing.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 -- Validates:
 -- 1) Non-admin (non-owner) cannot schedule a post
--- 2) blog_admin_schedule sets status=scheduled + publish_at, clears published_at
+-- 2) blog_schedule_post sets status=scheduled + publish_at, clears published_at
 -- 3) A future publish time is rejected
 -- 4) blog_publish_due() leaves not-yet-due posts alone
 -- 5) blog_publish_due() flips due posts to published (published_at = publish_at)
@@ -63,7 +63,7 @@ BEGIN
   PERFORM set_config('request.jwt.claim.role', 'authenticated', true);
   PERFORM set_config('request.jwt.claim.sub', v_user::text, true);
   BEGIN
-    PERFORM public.blog_admin_schedule(v_blog, timezone('utc', now()) + interval '1 day');
+    PERFORM public.blog_schedule_post(v_blog, timezone('utc', now()) + interval '1 day');
     RAISE EXCEPTION 'FAIL: non-admin was allowed to schedule a post';
   EXCEPTION WHEN insufficient_privilege THEN NULL; END;
 
@@ -72,12 +72,12 @@ BEGIN
 
   -- 3) Past publish time rejected.
   BEGIN
-    PERFORM public.blog_admin_schedule(v_blog, timezone('utc', now()) - interval '1 hour');
+    PERFORM public.blog_schedule_post(v_blog, timezone('utc', now()) - interval '1 hour');
     RAISE EXCEPTION 'FAIL: a past publish time was accepted';
   EXCEPTION WHEN sqlstate '22023' THEN NULL; END;
 
   -- 2) Schedule for the future.
-  v_res := public.blog_admin_schedule(v_blog, timezone('utc', now()) + interval '1 day');
+  v_res := public.blog_schedule_post(v_blog, timezone('utc', now()) + interval '1 day');
   SELECT status::text, published_at, publish_at
   INTO v_status, v_published_at, v_publish_at
   FROM public.blogs WHERE id = v_blog;

--- a/supabase/verify/verify_scheduled_publishing.sql
+++ b/supabase/verify/verify_scheduled_publishing.sql
@@ -1,0 +1,129 @@
+-- ============================================================================
+-- Scheduled publishing verification (rollback-only)
+-- ============================================================================
+-- Validates:
+-- 1) Non-admin (non-owner) cannot schedule a post
+-- 2) blog_admin_schedule sets status=scheduled + publish_at, clears published_at
+-- 3) A future publish time is rejected
+-- 4) blog_publish_due() leaves not-yet-due posts alone
+-- 5) blog_publish_due() flips due posts to published (published_at = publish_at)
+--
+-- Usage:
+--   yarn db:verify:scheduled-publishing
+--
+-- Runs in a transaction and ends with ROLLBACK. Tests the RPCs directly and
+-- does not depend on the pg_cron job actually firing.
+-- ============================================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_admin uuid := gen_random_uuid();
+  v_user uuid := gen_random_uuid();
+  v_blog uuid;
+  v_res jsonb;
+  v_status text;
+  v_published_at timestamptz;
+  v_publish_at timestamptz;
+  v_flipped int;
+BEGIN
+  -- ── Seed auth users + profiles ─────────────────────────────────────────
+  INSERT INTO auth.users (
+    instance_id, id, aud, role, email, encrypted_password,
+    email_confirmed_at, confirmation_token, recovery_token, email_change,
+    email_change_token_new, email_change_token_current, reauthentication_token,
+    raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+  )
+  VALUES
+    ('00000000-0000-0000-0000-000000000000', v_admin, 'authenticated',
+     'authenticated', 'sched.admin@example.com',
+     '$2a$10$QJ4j7aL1fXf9k7G3nYf3s.yfYb7fBQfFPHlyv5Q9ix8fJ0Eqv6c7u',
+     timezone('utc', now()), '', '', '', '', '', '',
+     '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+     timezone('utc', now()), timezone('utc', now())),
+    ('00000000-0000-0000-0000-000000000000', v_user, 'authenticated',
+     'authenticated', 'sched.user@example.com',
+     '$2a$10$QJ4j7aL1fXf9k7G3nYf3s.yfYb7fBQfFPHlyv5Q9ix8fJ0Eqv6c7u',
+     timezone('utc', now()), '', '', '', '', '', '',
+     '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+     timezone('utc', now()), timezone('utc', now()));
+
+  INSERT INTO public.user_profiles (id, username, first_name, last_name, role)
+  VALUES
+    (v_admin, 'sched_admin', 'Sched', 'Admin', 'admin'),
+    (v_user, 'sched_user', 'Sched', 'User', 'user')
+  ON CONFLICT (id) DO UPDATE SET role = EXCLUDED.role;
+
+  INSERT INTO public.blogs (slug, title, content, author_id, author, status)
+  VALUES ('sched-post', 'Scheduled Post', 'body', v_admin, 'sched_admin', 'draft')
+  RETURNING id INTO v_blog;
+
+  -- ── 1) Non-admin (non-owner) is denied ─────────────────────────────────
+  PERFORM set_config('request.jwt.claim.role', 'authenticated', true);
+  PERFORM set_config('request.jwt.claim.sub', v_user::text, true);
+  BEGIN
+    PERFORM public.blog_admin_schedule(v_blog, timezone('utc', now()) + interval '1 day');
+    RAISE EXCEPTION 'FAIL: non-admin was allowed to schedule a post';
+  EXCEPTION WHEN insufficient_privilege THEN NULL; END;
+
+  -- ── Admin session ──────────────────────────────────────────────────────
+  PERFORM set_config('request.jwt.claim.sub', v_admin::text, true);
+
+  -- 3) Past publish time rejected.
+  BEGIN
+    PERFORM public.blog_admin_schedule(v_blog, timezone('utc', now()) - interval '1 hour');
+    RAISE EXCEPTION 'FAIL: a past publish time was accepted';
+  EXCEPTION WHEN sqlstate '22023' THEN NULL; END;
+
+  -- 2) Schedule for the future.
+  v_res := public.blog_admin_schedule(v_blog, timezone('utc', now()) + interval '1 day');
+  SELECT status::text, published_at, publish_at
+  INTO v_status, v_published_at, v_publish_at
+  FROM public.blogs WHERE id = v_blog;
+
+  IF v_status <> 'scheduled' THEN
+    RAISE EXCEPTION 'FAIL: expected status scheduled, got %', v_status;
+  END IF;
+  IF v_publish_at IS NULL THEN
+    RAISE EXCEPTION 'FAIL: publish_at was not set';
+  END IF;
+  IF v_published_at IS NOT NULL THEN
+    RAISE EXCEPTION 'FAIL: published_at should be null while scheduled';
+  END IF;
+
+  -- 4) Not yet due → publish_due leaves it scheduled.
+  v_flipped := public.blog_publish_due();
+  SELECT status::text INTO v_status FROM public.blogs WHERE id = v_blog;
+  IF v_status <> 'scheduled' THEN
+    RAISE EXCEPTION 'FAIL: not-yet-due post was published early (flipped=%)', v_flipped;
+  END IF;
+
+  -- 5) Make it due (simulate time passing), then publish_due flips it.
+  UPDATE public.blogs
+  SET publish_at = timezone('utc', now()) - interval '1 minute'
+  WHERE id = v_blog;
+
+  v_flipped := public.blog_publish_due();
+  IF v_flipped < 1 THEN
+    RAISE EXCEPTION 'FAIL: blog_publish_due reported % flips, expected >= 1', v_flipped;
+  END IF;
+
+  SELECT status::text, published_at, publish_at
+  INTO v_status, v_published_at, v_publish_at
+  FROM public.blogs WHERE id = v_blog;
+
+  IF v_status <> 'published' THEN
+    RAISE EXCEPTION 'FAIL: due post was not published (status=%)', v_status;
+  END IF;
+  IF v_published_at IS NULL THEN
+    RAISE EXCEPTION 'FAIL: published_at was not set on publish';
+  END IF;
+  IF v_published_at <> v_publish_at THEN
+    RAISE EXCEPTION 'FAIL: published_at (%) should equal publish_at (%)', v_published_at, v_publish_at;
+  END IF;
+
+  RAISE NOTICE 'PASS: scheduled publishing verification succeeded';
+END $$;
+
+ROLLBACK;

--- a/supabase/verify/verify_scheduled_publishing.sql
+++ b/supabase/verify/verify_scheduled_publishing.sql
@@ -22,6 +22,7 @@ DECLARE
   v_admin uuid := gen_random_uuid();
   v_user uuid := gen_random_uuid();
   v_blog uuid;
+  v_blog2 uuid;
   v_res jsonb;
   v_status text;
   v_published_at timestamptz;
@@ -121,6 +122,49 @@ BEGIN
   END IF;
   IF v_published_at <> v_publish_at THEN
     RAISE EXCEPTION 'FAIL: published_at (%) should equal publish_at (%)', v_published_at, v_publish_at;
+  END IF;
+
+  -- ── Native scheduling through the create/update RPCs (the editor path) ──
+  -- 6) Create a post already scheduled.
+  v_res := public.blog_admin_create(jsonb_build_object(
+    'title', 'Created Scheduled',
+    'content', 'body',
+    'status', 'scheduled',
+    'publish_at', (timezone('utc', now()) + interval '2 days')::text
+  ));
+  v_blog2 := (v_res ->> 'id')::uuid;
+  IF (v_res ->> 'publishAt') IS NULL THEN
+    RAISE EXCEPTION 'FAIL: created row json is missing publishAt';
+  END IF;
+  SELECT status::text, publish_at INTO v_status, v_publish_at
+  FROM public.blogs WHERE id = v_blog2;
+  IF v_status <> 'scheduled' OR v_publish_at IS NULL THEN
+    RAISE EXCEPTION 'FAIL: create-with-schedule state wrong (status=%, publish_at=%)', v_status, v_publish_at;
+  END IF;
+
+  -- 7) Creating scheduled without publish_at is rejected.
+  BEGIN
+    PERFORM public.blog_admin_create(jsonb_build_object(
+      'title', 'No Time', 'content', 'b', 'status', 'scheduled'));
+    RAISE EXCEPTION 'FAIL: scheduled create without publish_at was accepted';
+  EXCEPTION WHEN sqlstate '23514' THEN NULL; END;
+
+  -- 8) Leaving scheduled via update clears publish_at.
+  PERFORM public.blog_admin_update(v_blog2, jsonb_build_object('status', 'draft'));
+  SELECT status::text, publish_at INTO v_status, v_publish_at
+  FROM public.blogs WHERE id = v_blog2;
+  IF v_status <> 'draft' OR v_publish_at IS NOT NULL THEN
+    RAISE EXCEPTION 'FAIL: leaving scheduled did not clear publish_at (status=%, publish_at=%)', v_status, v_publish_at;
+  END IF;
+
+  -- 9) Update back into scheduled with a fresh time.
+  PERFORM public.blog_admin_update(v_blog2, jsonb_build_object(
+    'status', 'scheduled',
+    'publish_at', (timezone('utc', now()) + interval '3 days')::text));
+  SELECT status::text, publish_at INTO v_status, v_publish_at
+  FROM public.blogs WHERE id = v_blog2;
+  IF v_status <> 'scheduled' OR v_publish_at IS NULL THEN
+    RAISE EXCEPTION 'FAIL: update-to-scheduled did not persist (status=%, publish_at=%)', v_status, v_publish_at;
   END IF;
 
   RAISE NOTICE 'PASS: scheduled publishing verification succeeded';


### PR DESCRIPTION
## Summary
Implements scheduled publishing for blog posts, allowing authors to set a future publication date that automatically publishes the post via a pg_cron job. Posts can be authored with a `scheduled` status and `publish_at` timestamp, and a system job flips due posts to `published` every minute without user intervention.

## Key Changes

**Database Migrations:**
- Added `scheduled` enum value to `blog_status` type (migration 20260718000100)
- Added `publish_at` timestamptz column to blogs table with partial index on scheduled posts (migration 20260718000200)
- Created `blog_schedule_post(uuid, timestamptz)` RPC for scheduling posts with RBAC enforcement
- Created `blog_publish_due()` system RPC that publishes all due scheduled posts
- Set up pg_cron job to run `blog_publish_due()` every minute
- Redefined `blog_admin_create()` and `blog_admin_update()` RPCs to accept and validate `publish_at` payload key (migration 20260718000300)
- Updated `blog_json_row_fragment()` to expose `publishAt` field for editor prefilling

**Frontend - Blog Editor (Create/Edit):**
- Added `publishAt` field to form schema and validation
- Added `handleSchedule()` function to set status to `scheduled` and submit with ISO datetime
- Added "Schedule" button alongside "Save Draft" and "Publish" buttons
- Implemented `toDateTimeLocal()` helper to convert ISO datetimes to `datetime-local` input format
- Form now persists `publishAt` in draft storage

**Frontend - Blog List (AllBlogs):**
- Added schedule dialog with datetime-local picker (defaults to 1 hour from now)
- Added "Schedule…" menu item for draft/non-scheduled posts
- Added "Publish now" menu item for scheduled posts to override and publish immediately
- Updated status badge styling to show `scheduled` posts with outline variant
- Integrated `scheduleBlog()` and `publishNow()` store actions

**Services & Store:**
- Added `scheduleBlog(blogId, publishAtIso)` service method calling `blog_schedule_post` RPC
- Added `publishNow(blogId)` service method to immediately publish a post
- Updated `buildPayloadFromFormData()` to include `publish_at` when present
- Added store actions for scheduling and immediate publishing

**Type Updates:**
- Extended `BlogStatus` type to include `"scheduled"`
- Added `publishAt?: IsoDateString` field to `BlogPost` interface
- Updated `BlogDraftStatus` to include `"scheduled"`
- Updated form validation schema to accept `"scheduled"` status

**Testing:**
- Added comprehensive verification script (`verify_scheduled_publishing.sql`) covering:
  - RBAC enforcement (non-owners cannot schedule)
  - Future-date validation
  - `blog_publish_due()` behavior for not-yet-due and due posts
  - Create/update RPC scheduling paths
  - State transitions (scheduled → draft → scheduled)

## Implementation Details
- Scheduled posts remain hidden from public read RPCs until published (status check is sufficient)
- `publish_at` is required and must be future-dated when `status = 'scheduled'`
- Leaving the scheduled state (via update) automatically clears `publish_at`
- `published_at` is set to `publish_at` when the cron job publishes (or current time if `publish_at` is null)
- Editor datetime picker uses local timezone; cron job operates in UTC
- All scheduling RPCs enforce RBAC via `blog_assert_blog_write_access()` (row author or admin only)
