### PR TITLE
Update CommandPalette to navigate to dashboard post views

### DIFF
--- a/src/components/shared/CommandPalette.tsx
+++ b/src/components/shared/CommandPalette.tsx
@@ -4,11 +4,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   FileText,
+  FolderOpen,
   LayoutDashboard,
   Loader2,
+  MessageSquare,
   Newspaper,
   Plus,
-  Tag,
+  Tags,
 } from "lucide-react";
 import {
   Command,
@@ -38,14 +40,19 @@ const DASHBOARD_NAV = [
   { label: "Dashboard overview", href: "/dashboard", Icon: LayoutDashboard },
   { label: "All blogs", href: "/dashboard/blogs", Icon: FileText },
   { label: "New blog", href: "/dashboard/blogs/new", Icon: Plus },
-  { label: "Categories", href: "/dashboard/categories", Icon: Tag },
+  { label: "Categories", href: "/dashboard/categories", Icon: FolderOpen },
+  { label: "Tags", href: "/dashboard/tags", Icon: Tags },
+  { label: "Comments", href: "/dashboard/comments", Icon: MessageSquare },
 ] as const;
 
+/** Admin post view inside the dashboard (never the public article page). */
+const dashboardPostHref = (id: string) => `/dashboard/blogs/${id}`;
+
 /**
- * Dashboard ⌘K palette: jump to dashboard views, recent posts, or any
- * published article via server-driven search. Post search is debounced and
- * remote, so cmdk's own filtering is off; article selection opens the
- * published page.
+ * Dashboard ⌘K palette: jump to dashboard views, recent posts, or any post
+ * via server-driven search. Post search is debounced and remote, so cmdk's
+ * own filtering is off; selecting a post opens it inside the dashboard (its
+ * admin detail page) so the admin never leaves the dashboard.
  */
 export function CommandPalette() {
   const router = useRouter();
@@ -161,7 +168,7 @@ export function CommandPalette() {
               <CommandItem
                 key={post.id}
                 value={`post-${post.id}`}
-                onSelect={() => navigate(`/blog/${post.slug}`)}
+                onSelect={() => navigate(dashboardPostHref(post.id))}
               >
                 <FileText aria-hidden />
                 <span className="truncate">{post.title}</span>
@@ -176,7 +183,7 @@ export function CommandPalette() {
               <CommandItem
                 key={post.id}
                 value={`recent-${post.id}`}
-                onSelect={() => navigate(`/blog/${post.slug}`)}
+                onSelect={() => navigate(dashboardPostHref(post.id))}
               >
                 <Newspaper aria-hidden />
                 <span className="truncate">{post.title}</span>


### PR DESCRIPTION
## Summary
Updated the CommandPalette component to navigate to admin dashboard post detail pages instead of public blog pages, ensuring admins stay within the dashboard when searching for posts.

## Key Changes
- **Navigation behavior**: Changed post selection to navigate to `/dashboard/blogs/{id}` instead of `/blog/{slug}`, keeping admins in the dashboard context
- **New dashboard sections**: Added "Tags" and "Comments" navigation items to the dashboard menu
- **Icon updates**: 
  - Changed "Categories" icon from `Tag` to `FolderOpen` for better visual distinction
  - Added `Tags` icon for the new Tags section
  - Added `MessageSquare` icon for the new Comments section
- **Code organization**: Extracted post navigation logic into a `dashboardPostHref()` helper function for consistency
- **Documentation**: Updated JSDoc comments to clarify that the palette now opens posts in the admin detail page rather than the public article page

## Implementation Details
- The `dashboardPostHref()` helper function centralizes the dashboard post URL pattern, making it easier to maintain and update in the future
- Both search results and recent posts sections now use the same navigation pattern
- The updated documentation makes it clear that this is an admin-only experience within the dashboard

https://claude.ai/code/session_012wEn9ZfMjimvXJ1eKagcY5